### PR TITLE
✨  Feat : API 응답통일, 에러핸들러 설계

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,11 +22,22 @@ repositories {
 }
 
 dependencies {
+	// spring data jpa
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+	// spring mvc
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	// lombok
 	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	// validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// mysql
+	runtimeOnly 'com.mysql:mysql-connector-j'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/src/main/java/treehouse/server/global/common/CommonResponse.java
+++ b/src/main/java/treehouse/server/global/common/CommonResponse.java
@@ -1,0 +1,58 @@
+package treehouse.server.global.common;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder( {"isSuccess", "code", "message", "data"} )
+public class CommonResponse<T> {
+    @Override
+    public String toString() {
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            // Java 8 날짜/시간 모듈 등록
+            mapper.registerModule(new JavaTimeModule());
+            // 날짜와 시간을 ISO-8601 형식의 문자열로 직렬화
+            mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+            // 이쁘게 출력하기
+            return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @JsonProperty("isSuccess")
+    private Boolean isSuccess;
+    @JsonProperty("code")
+    private String code;
+    @JsonProperty("message")
+    private String message;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd")
+    @JsonProperty("createdAt")
+    private LocalDateTime createdAt;
+    @JsonProperty("data")
+    private T data;
+
+    // 성공한 경우 응답 생성
+
+    public static <T> CommonResponse<T> onSuccess(T data){
+        return new CommonResponse<>(true, "200" , "요청에 성공하였습니다.", LocalDateTime.now(), data);
+    }
+
+    // 실패한 경우 응답 생성
+    public static <T> CommonResponse<T> onFailure(String code, String message, T data){
+        return new CommonResponse<>(false,code, message, LocalDateTime.now(), data);
+    }
+
+}

--- a/src/main/java/treehouse/server/global/exception/BaseErrorCode.java
+++ b/src/main/java/treehouse/server/global/exception/BaseErrorCode.java
@@ -1,0 +1,10 @@
+package treehouse.server.global.exception;
+
+import treehouse.server.global.exception.dto.ErrorResponseDTO;
+
+public interface BaseErrorCode {
+
+    public ErrorResponseDTO getReason();
+
+    public ErrorResponseDTO getReasonHttpStatus();
+}

--- a/src/main/java/treehouse/server/global/exception/GeneralExceptionHandler.java
+++ b/src/main/java/treehouse/server/global/exception/GeneralExceptionHandler.java
@@ -1,0 +1,169 @@
+package treehouse.server.global.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.constraints.NotNull;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import treehouse.server.global.common.CommonResponse;
+import treehouse.server.global.exception.ThrowClass.GeneralException;
+import treehouse.server.global.exception.dto.ErrorResponseDTO;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@RestControllerAdvice(annotations = {RestController.class})
+public class GeneralExceptionHandler extends ResponseEntityExceptionHandler {
+
+//    @ExceptionHandler(value = { GeneralException.class})
+//    protected ApiResponse handleCustomException(GeneralException e) {
+//        log.error("handleCustomException throw CustomException : {}", e.getErrorCode());
+//        return ApiResponse.onFailure(e.getErrorCode(), "");
+//    }
+
+
+    @ExceptionHandler
+    public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
+        String errorMessage =
+                e.getConstraintViolations().stream()
+                        .map(constraintViolation -> constraintViolation.getMessage())
+                        .findFirst()
+                        .orElseThrow(
+                                () ->
+                                        new RuntimeException(
+                                                "ConstraintViolationException 추출 도중 에러 발생"));
+
+        return handleExceptionInternalConstraint(
+                e, GlobalErrorCode.valueOf(errorMessage), HttpHeaders.EMPTY, request);
+    }
+
+    @Override
+    @NotNull
+    public ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex,
+            HttpHeaders headers,
+            HttpStatusCode status,
+            WebRequest request) {
+
+        Map<String, String> errors = new LinkedHashMap<>();
+
+        ex.getBindingResult().getFieldErrors().stream()
+                .forEach(
+                        fieldError -> {
+                            String fieldName = fieldError.getField();
+                            String errorMessage =
+                                    Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
+                            errors.merge(
+                                    fieldName,
+                                    errorMessage,
+                                    (existingErrorMessage, newErrorMessage) ->
+                                            existingErrorMessage + ", " + newErrorMessage);
+                        });
+
+        return handleExceptionInternalArgs(
+                ex, HttpHeaders.EMPTY, GlobalErrorCode.valueOf("BAD_ARGS_ERROR"), request, errors);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<Object> exception(Exception e, WebRequest request) {
+        e.printStackTrace();
+
+        return handleExceptionInternalFalse(
+                e,
+                GlobalErrorCode.SERVER_ERROR,
+                HttpHeaders.EMPTY,
+                GlobalErrorCode.SERVER_ERROR.getHttpStatus(),
+                request,
+                e.getMessage());
+    }
+
+    /* Todo
+        Spring Security 작업 이후 주석 제거
+     */
+//    @ExceptionHandler(value = GeneralException.class)
+//    public ResponseEntity onThrowException(
+//            GeneralException generalException,
+//            @AuthenticationPrincipal User user,
+//            HttpServletRequest request) {
+////        getExceptionStackTrace(generalException, user, request);
+////        GlobalErrorCode errorCode = generalException.getErrorCode();
+//        ErrorReasonDTO errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
+//        return handleExceptionInternal(generalException, errorReasonHttpStatus, null, request);
+//    }
+
+    private ResponseEntity<Object> handleExceptionInternal(
+            Exception e, ErrorResponseDTO reason, HttpHeaders headers, HttpServletRequest request) {
+
+        CommonResponse<Object> body =
+                CommonResponse.onFailure(reason.getCode(), reason.getMessage(), null);
+        e.printStackTrace();
+
+        WebRequest webRequest = new ServletWebRequest(request);
+        return super.handleExceptionInternal(
+                e, body, headers, reason.getHttpStatus(), webRequest);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalFalse(
+            Exception e,
+            GlobalErrorCode errorCode,
+            HttpHeaders headers,
+            HttpStatus status,
+            WebRequest request,
+            String errorPoint) {
+        CommonResponse<Object> body =
+                CommonResponse.onFailure(errorCode.getCode(), errorCode.getMessage(), errorPoint);
+        return super.handleExceptionInternal(e, body, headers, status, request);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalArgs(
+            Exception e,
+            HttpHeaders headers,
+            GlobalErrorCode errorCode,
+            WebRequest request,
+            Map<String, String> errorArgs) {
+        CommonResponse<Object> body =
+                CommonResponse.onFailure(errorCode.getCode(), errorCode.getMessage(), errorArgs);
+        return super.handleExceptionInternal(e, body, headers, errorCode.getHttpStatus(), request);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalConstraint(
+            Exception e, GlobalErrorCode errorCode, HttpHeaders headers, WebRequest request) {
+        CommonResponse<Object> body =
+                CommonResponse.onFailure(errorCode.getCode(), errorCode.getMessage(), null);
+        return super.handleExceptionInternal(e, body, headers, errorCode.getHttpStatus(), request);
+    }
+
+    /*
+    Todo
+        Spring Security 작업 이후 주석 제거
+     */
+
+//    private void getExceptionStackTrace(
+//            Exception e, @AuthenticationPrincipal User user, HttpServletRequest request) {
+//        StringWriter sw = new StringWriter();
+//        PrintWriter pw = new PrintWriter(sw);
+//
+//        pw.append("\n==========================!!!ERROR TRACE!!!==========================\n");
+//        pw.append("uri: " + request.getRequestURI() + " " + request.getMethod() + "\n");
+//        if (user != null) {
+//            pw.append("uid: " + user.getUsername() + "\n");
+//        }
+//        pw.append(e.getMessage());
+//        pw.append("\n=====================================================================");
+//        log.error(sw.toString());
+//    }
+}

--- a/src/main/java/treehouse/server/global/exception/GlobalErrorCode.java
+++ b/src/main/java/treehouse/server/global/exception/GlobalErrorCode.java
@@ -1,0 +1,105 @@
+package treehouse.server.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import treehouse.server.global.exception.dto.ErrorResponseDTO;
+
+import static org.springframework.http.HttpStatus.*;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+@Getter
+@RequiredArgsConstructor
+public enum GlobalErrorCode implements BaseErrorCode{
+
+    // 500 Server Error
+    SERVER_ERROR(INTERNAL_SERVER_ERROR, "GLOBAL500_1", "서버 에러, 서버 개발자에게 알려주세요."),
+
+    // Args Validation Error
+    BAD_ARGS_ERROR(BAD_REQUEST, "GLOBAL400_1", "request body의 validation이 실패했습니다. 응답 body를 참고해주세요"),
+
+    //  Member
+    // 400 BAD_REQUEST - 잘못된 요청
+    NOT_VALID_PHONE_NUMBER(BAD_REQUEST, "USER400_1", "유효하지 않은 전화번호 입니다."),
+
+    // 401 Unauthorized - 권한 없음
+
+    // 403 Forbidden - 인증 거부
+
+    // 404 Not Found - 찾을 수 없음
+    MEMBER_NOT_FOUND(NOT_FOUND, "USER404_1", "등록된 사용자 정보가 없습니다."),
+
+
+    // 409 CONFLICT : Resource 를 찾을 수 없음
+    DUPLICATE_PHONE_NUMBER(CONFLICT, "USER409_1", "중복된 전화번호가 존재합니다."),
+
+    //Profile
+    //404 Not Found - 찾을 수 없음
+    PROFILE_NOT_FOUND(NOT_FOUND, "MEMBER404_1", "존재하지 않는 프로필입니다."),
+    AVAILABLE_PROFILE_NOT_FOUND(NOT_FOUND, "MEMBER404_2", "현재 선택된 프로필이 없습니다."),
+
+    //Treehouse
+    //404 Not Found - 찾을 수 없음
+    TREEHOUSE_NOT_FOUND(NOT_FOUND, "TREEHOUSE404_1", "존재하지 않는 트리입니다."),
+
+    //Invitation
+    //404 Not Found - 찾을 수 없음
+    INVITATION_NOT_FOUND(NOT_FOUND, "INVITATION404_1", "존재하지 않는 초대장입니다."),
+
+    //Post
+    //404 Not Found - 찾을 수 없음
+    POST_NOT_FOUND(NOT_FOUND, "POST404_1", "존재하지 않는 게시글입니다."),
+
+    //Comment
+    //404 Not Found - 찾을 수 없음
+    COMMENT_NOT_FOUND(NOT_FOUND, "COMMENT404_1", "존재하지 않는 댓글입니다."),
+
+    //Reply
+    //404 Not Found - 찾을 수 없음
+    REPLY_NOT_FOUND(NOT_FOUND, "REPLY404_1", "존재하지 않는 답글입니다."),
+
+    //Branch
+    //404 Not Found - 찾을 수 없음
+    BRANCH_NOT_FOUND(NOT_FOUND, "BRANCH404_1", "브랜치 정보를 찾을 수 없습니다."),
+
+    //Notification
+    //404 Not Found - 찾을 수 없음
+    NOTIFICATION_NOT_FOUND(NOT_FOUND, "NOTIFICATION", "존재하지 않는 알림입니다."),
+
+    //FeignClient
+    FEIGN_CLIENT_ERROR_400(BAD_REQUEST, "FEIGN400", "feignClient 에서 400번대 에러가 발생했습니다."),
+    FEIGN_CLIENT_ERROR_500(INTERNAL_SERVER_ERROR, "FEIGN500", "feignClient 에서 500번대 에러가 발생했습니다."),
+
+    // NCP Phone Auth
+    PHONE_NUMBER_EXIST(OK, "NCP200_1", "이미 인증된 전화번호입니다."),
+    PHONE_AUTH_NOT_FOUND(BAD_REQUEST, "NCP400_1", "인증 번호 요청이 필요합니다."),
+    PHONE_AUTH_WRONG(BAD_REQUEST, "NCP400_2", "잘못된 인증 번호 입니다."),
+    PHONE_AUTH_TIMEOUT(BAD_REQUEST, "NCP400_3", "인증 시간이 초과되었습니다."),
+
+    ;
+
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorResponseDTO getReason() {
+        return ErrorResponseDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public ErrorResponseDTO getReasonHttpStatus() {
+        return ErrorResponseDTO.builder()
+                .message(message)
+                .code(code)
+                .httpStatus(httpStatus)
+                .isSuccess(false)
+                .build();
+    }
+
+}

--- a/src/main/java/treehouse/server/global/exception/ThrowClass/GeneralException.java
+++ b/src/main/java/treehouse/server/global/exception/ThrowClass/GeneralException.java
@@ -1,0 +1,21 @@
+package treehouse.server.global.exception.ThrowClass;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import treehouse.server.global.exception.BaseErrorCode;
+import treehouse.server.global.exception.dto.ErrorResponseDTO;
+
+@Getter
+@AllArgsConstructor
+public class GeneralException extends RuntimeException {
+
+    private final BaseErrorCode errorCode;
+
+    public ErrorResponseDTO getErrorReason() {
+        return this.errorCode.getReason();
+    }
+
+    public ErrorResponseDTO getErrorReasonHttpStatus() {
+        return this.errorCode.getReasonHttpStatus();
+    }
+}

--- a/src/main/java/treehouse/server/global/exception/dto/ErrorResponseDTO.java
+++ b/src/main/java/treehouse/server/global/exception/dto/ErrorResponseDTO.java
@@ -1,0 +1,16 @@
+package treehouse.server.global.exception.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ErrorResponseDTO {
+
+    private HttpStatus httpStatus;
+
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+}


### PR DESCRIPTION
# 🚀 개요

✨  Feat : API 응답통일, 에러핸들러 설계

## 🔍 변경사항
- RestControllerAdvice를 통한 전역적인 에러 핸들링 추가
- API 응답의 형태를 통일
- API 응답에 필요한 Enum 추가

## ⏳ 작업 내용
- [x] API 응답통일
- [x] 에러 들러 추가

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

