### PR TITLE
Feat/19 시큐리티 세팅 및 Invitation 관련 로직 추가, 초대장 조회 API 구현

### DIFF
--- a/src/main/java/treehouse/server/api/invitation/business/InvitationMapper.java
+++ b/src/main/java/treehouse/server/api/invitation/business/InvitationMapper.java
@@ -1,0 +1,34 @@
+package treehouse.server.api.invitation.business;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Component;
+import treehouse.server.api.invitation.presentation.dto.InvitationResponseDTO;
+import treehouse.server.global.entity.Invitation.Invitation;
+import treehouse.server.global.entity.User.User;
+import treehouse.server.global.entity.User.UserRole;
+import treehouse.server.global.entity.User.UserStatus;
+
+import java.util.List;
+
+@Component
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class InvitationMapper {
+
+    public InvitationResponseDTO.getInvitation toGetInvitation (Invitation invitation, List<String> treeMemberProfileImages) {
+        return InvitationResponseDTO.getInvitation.builder()
+                .invitationId(invitation.getId())
+                .treehouseName(invitation.getTreeHouse().getName())
+                .senderName(invitation.getSender().getName())
+                .senderProfileImageUrl(invitation.getSender().getProfileImageUrl())
+                .treehouseSize(invitation.getTreeHouse().getMemberList().size())
+                .treehouseMemberProfileImages(treeMemberProfileImages)
+                .build();
+    }
+    public InvitationResponseDTO.getInvitations toGetInvitations(List<InvitationResponseDTO.getInvitation> invitationDtos) {
+        return InvitationResponseDTO.getInvitations.builder()
+                .invitations(invitationDtos)
+                .build();
+    }
+}
+

--- a/src/main/java/treehouse/server/api/invitation/business/InvitationService.java
+++ b/src/main/java/treehouse/server/api/invitation/business/InvitationService.java
@@ -1,0 +1,60 @@
+package treehouse.server.api.invitation.business;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import treehouse.server.api.invitation.implement.InvitationCommandAdapter;
+import treehouse.server.api.invitation.implement.InvitationQueryAdapter;
+import treehouse.server.api.invitation.presentation.dto.InvitationRequestDTO;
+import treehouse.server.api.invitation.presentation.dto.InvitationResponseDTO;
+import treehouse.server.global.entity.Invitation.Invitation;
+import treehouse.server.global.entity.User.User;
+import treehouse.server.global.entity.member.Member;
+import treehouse.server.global.entity.redis.RefreshToken;
+import treehouse.server.global.entity.treeHouse.TreeHouse;
+import treehouse.server.global.exception.GlobalErrorCode;
+import treehouse.server.global.exception.ThrowClass.AuthException;
+import treehouse.server.global.exception.ThrowClass.GeneralException;
+import treehouse.server.global.redis.service.RedisService;
+import treehouse.server.global.security.jwt.dto.TokenDTO;
+import treehouse.server.global.security.provider.TokenProvider;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@AllArgsConstructor
+@Slf4j
+public class InvitationService {
+
+
+    private final InvitationQueryAdapter invitationQueryAdapter;
+
+    private final InvitationCommandAdapter invitationCommandAdapter;
+    private final InvitationMapper invitationMapper;
+    private static final Integer treeMemberRandomProfileSize = 3;
+
+
+    @Transactional
+    public InvitationResponseDTO.getInvitations getInvitations(User user) {
+
+        log.error("User name : ", user.getName());
+        log.error("User id : ", user.getId());
+        List<Invitation> invitations = invitationQueryAdapter.findAllByPhone(user.getPhone());
+        log.error("size : ", invitations.size());
+
+        List<InvitationResponseDTO.getInvitation> invitationDtos = invitations.stream()
+                .map(invitation -> {
+                    TreeHouse treeHouse = invitation.getTreeHouse();
+                    List<Member> treeMembers = treeHouse.getMemberList();
+                    List<String> randomProfileImages = treeMembers.stream()
+                            .map(Member::getProfileImageUrl)
+                            .limit(treeMemberRandomProfileSize)
+                            .toList();
+                    return invitationMapper.toGetInvitation(invitation, randomProfileImages);
+                })
+                .collect(Collectors.toList());
+        return invitationMapper.toGetInvitations(invitationDtos);
+    }
+}

--- a/src/main/java/treehouse/server/api/invitation/implement/InvitationCommandAdapter.java
+++ b/src/main/java/treehouse/server/api/invitation/implement/InvitationCommandAdapter.java
@@ -1,0 +1,25 @@
+package treehouse.server.api.invitation.implement;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import treehouse.server.api.invitation.persistence.InvitationRepository;
+import treehouse.server.global.annotations.Adapter;
+import treehouse.server.global.entity.User.User;
+import treehouse.server.global.entity.User.UserRole;
+import treehouse.server.global.entity.redis.RefreshToken;
+import treehouse.server.global.redis.service.RedisService;
+import treehouse.server.global.security.jwt.dto.TokenDTO;
+import treehouse.server.global.security.provider.TokenProvider;
+
+import java.util.List;
+
+@Adapter
+@Slf4j
+@RequiredArgsConstructor
+public class InvitationCommandAdapter {
+
+    private final InvitationRepository invitationRepository;
+
+
+}

--- a/src/main/java/treehouse/server/api/invitation/implement/InvitationQueryAdapter.java
+++ b/src/main/java/treehouse/server/api/invitation/implement/InvitationQueryAdapter.java
@@ -1,0 +1,26 @@
+package treehouse.server.api.invitation.implement;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import treehouse.server.api.invitation.persistence.InvitationRepository;
+import treehouse.server.api.invitation.presentation.dto.InvitationRequestDTO;
+import treehouse.server.global.annotations.Adapter;
+import treehouse.server.global.entity.Invitation.Invitation;
+import treehouse.server.global.entity.User.User;
+import treehouse.server.global.exception.GlobalErrorCode;
+import treehouse.server.global.exception.ThrowClass.UserException;
+
+import java.util.List;
+import java.util.Optional;
+
+@Adapter
+@RequiredArgsConstructor
+public class InvitationQueryAdapter {
+
+    private final InvitationRepository invitationRepository;
+
+    public List<Invitation> findAllByPhone(String phone) {
+        return invitationRepository.findAllByPhone(phone);
+    }
+
+}

--- a/src/main/java/treehouse/server/api/invitation/persistence/InvitationRepository.java
+++ b/src/main/java/treehouse/server/api/invitation/persistence/InvitationRepository.java
@@ -1,0 +1,16 @@
+package treehouse.server.api.invitation.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import treehouse.server.global.entity.Invitation.Invitation;
+import treehouse.server.global.entity.User.User;
+import treehouse.server.global.entity.treeHouse.TreeHouse;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface InvitationRepository extends JpaRepository<Invitation, Long> {
+
+    List<Invitation> findAllByPhone(String phone);
+
+    Invitation findByPhoneAndTreeHouse(String phone, TreeHouse treeHouse);
+}

--- a/src/main/java/treehouse/server/api/invitation/presentation/InvitationApi.java
+++ b/src/main/java/treehouse/server/api/invitation/presentation/InvitationApi.java
@@ -1,0 +1,36 @@
+package treehouse.server.api.invitation.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import treehouse.server.api.invitation.business.InvitationService;
+import treehouse.server.api.invitation.presentation.dto.InvitationRequestDTO;
+import treehouse.server.api.invitation.presentation.dto.InvitationResponseDTO;
+import treehouse.server.global.common.CommonResponse;
+import treehouse.server.global.entity.User.User;
+import treehouse.server.global.security.handler.annotation.AuthMember;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@Validated
+@Tag(name = "😎 Invitation API", description = "초대장 관련 API 입니다. 초대장 조회, 전송 등의 API가 포함됩니다.")
+@RequestMapping("/invi")
+public class InvitationApi {
+
+    private final InvitationService invitationService;
+
+    @GetMapping("/invitation")
+    @Operation(summary = "초대장 조회", description = "내가 받은 초대장을 조회합니다.")
+    public CommonResponse<InvitationResponseDTO.getInvitations> getInvitations(
+            @AuthMember @Parameter(hidden = true) User user
+    ) {
+        return CommonResponse.onSuccess(invitationService.getInvitations(user));
+    }
+
+
+}

--- a/src/main/java/treehouse/server/api/invitation/presentation/dto/InvitationRequestDTO.java
+++ b/src/main/java/treehouse/server/api/invitation/presentation/dto/InvitationRequestDTO.java
@@ -1,0 +1,18 @@
+package treehouse.server.api.invitation.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+
+public class InvitationRequestDTO {
+
+
+
+
+}

--- a/src/main/java/treehouse/server/api/invitation/presentation/dto/InvitationResponseDTO.java
+++ b/src/main/java/treehouse/server/api/invitation/presentation/dto/InvitationResponseDTO.java
@@ -1,0 +1,31 @@
+package treehouse.server.api.invitation.presentation.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class InvitationResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class getInvitation {
+        private Long invitationId;
+        private String treehouseName;
+        private String senderName;
+        private String senderProfileImageUrl;
+        private Integer treehouseSize;
+        private List<String> treehouseMemberProfileImages;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class getInvitations {
+        List<InvitationResponseDTO.getInvitation> invitations;
+    }
+
+}

--- a/src/main/java/treehouse/server/api/user/business/UserMapper.java
+++ b/src/main/java/treehouse/server/api/user/business/UserMapper.java
@@ -1,14 +1,28 @@
 package treehouse.server.api.user.business;
 
+import jakarta.annotation.PostConstruct;
 import lombok.*;
+import org.springframework.stereotype.Component;
 import treehouse.server.api.user.presentation.dto.UserResponseDTO;
 import treehouse.server.global.entity.User.User;
 import treehouse.server.global.entity.User.UserRole;
 import treehouse.server.global.entity.User.UserStatus;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Component
+//@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@RequiredArgsConstructor
 public class UserMapper {
 
+    private final UserService userService;
+    private static UserService staticUserService;
+    @PostConstruct
+    public void init(){
+        this.staticUserService = this.userService;
+    }
+
+    public static User toUserSecurity(String id){
+        return staticUserService.findById(Long.valueOf(id));
+    }
 
     public static UserResponseDTO.checkName toCheckNameDTO(boolean isDuplicated){
         return UserResponseDTO.checkName.builder()

--- a/src/main/java/treehouse/server/api/user/business/UserService.java
+++ b/src/main/java/treehouse/server/api/user/business/UserService.java
@@ -36,6 +36,11 @@ public class UserService {
         return UserMapper.toCheckNameDTO(userQueryAdapter.checkName(request));
     }
 
+    @Transactional(readOnly = true)
+    public User findById(Long id){
+        return userQueryAdapter.findById(id);
+    }
+
     @Transactional
     public UserResponseDTO.registerUser register(UserRequestDTO.registerUser request){
         User user = UserMapper.toUser(request.getUserName(), request.getPhoneNumber());

--- a/src/main/java/treehouse/server/api/user/implement/UserQueryAdapter.java
+++ b/src/main/java/treehouse/server/api/user/implement/UserQueryAdapter.java
@@ -33,4 +33,8 @@ public class UserQueryAdapter {
     public User findById(Long id){
         return userRepository.findById(id).orElseThrow(()->new UserException(GlobalErrorCode.MEMBER_NOT_FOUND));
     }
+
+    public Optional<User> optionalUserFindById(Long id){
+        return userRepository.findById(id);
+    }
 }

--- a/src/main/java/treehouse/server/global/config/GlobalWebConfig.java
+++ b/src/main/java/treehouse/server/global/config/GlobalWebConfig.java
@@ -1,0 +1,27 @@
+package treehouse.server.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import treehouse.server.global.security.handler.annotation.resolver.AuthMemberArgumentResolver;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class GlobalWebConfig implements WebMvcConfigurer {
+
+    private final AuthMemberArgumentResolver authMemberArgumentResolver;
+
+    /**
+     * 컨트롤러 메서드의 특정 파라미터를 지원하는 커스텀한 ArgumentResolver를 추가
+     * @param resolverList
+     */
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolverList) {
+        resolverList.add(authMemberArgumentResolver);
+    }
+}

--- a/src/main/java/treehouse/server/global/config/SwaggerConfig.java
+++ b/src/main/java/treehouse/server/global/config/SwaggerConfig.java
@@ -1,7 +1,10 @@
 package treehouse.server.global.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,8 +18,21 @@ public class SwaggerConfig {
                 .description("Treehouse API 명세서")
                 .version("1.0.0");
 
+        String jwtSchemeName = "JWT TOKEN";
+        // API 요청헤더에 인증정보 포함
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+        // SecuritySchemes 등록
+        Components components = new Components()
+                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                        .name(jwtSchemeName)
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT"));
+
         return new OpenAPI()
                 .addServersItem(new Server().url("/"))
-                .info(info);
+                .info(info)
+                .addSecurityItem(securityRequirement)
+                .components(components);
     }
 }

--- a/src/main/java/treehouse/server/global/entity/Invitation/Invitation.java
+++ b/src/main/java/treehouse/server/global/entity/Invitation/Invitation.java
@@ -3,6 +3,7 @@ package treehouse.server.global.entity.Invitation;
 
 import jakarta.persistence.*;
 import lombok.*;
+import treehouse.server.global.entity.User.User;
 import treehouse.server.global.entity.common.BaseDateTimeEntity;
 import treehouse.server.global.entity.member.Member;
 import treehouse.server.global.entity.treeHouse.TreeHouse;
@@ -29,6 +30,10 @@ public class Invitation extends BaseDateTimeEntity {
     @JoinColumn(name = "senderId")
     @ManyToOne(fetch = FetchType.LAZY)
     private Member sender;
+
+    @JoinColumn(name = "receiverId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User receiver;
     @JoinColumn(name = "treeId")
     @ManyToOne(fetch = FetchType.LAZY)
     private TreeHouse treeHouse;

--- a/src/main/java/treehouse/server/global/security/handler/annotation/AuthMember.java
+++ b/src/main/java/treehouse/server/global/security/handler/annotation/AuthMember.java
@@ -1,4 +1,11 @@
 package treehouse.server.global.security.handler.annotation;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME) // 런타임 중에 어노테이션 정보를 조회하고 처리할 수 있도록 설정
+@Target(ElementType.PARAMETER) // 어노테이션을 파라미터에만 적용
 public @interface AuthMember {
 }

--- a/src/main/java/treehouse/server/global/security/handler/annotation/resolver/AuthMemberArgumentResolver.java
+++ b/src/main/java/treehouse/server/global/security/handler/annotation/resolver/AuthMemberArgumentResolver.java
@@ -40,7 +40,7 @@ public class AuthMemberArgumentResolver implements HandlerMethodArgumentResolver
      * resolveArgument
      * 실제로 파라미터의 값을 해석해주는 메서드
      *  파라미터에 전달할 객체를 반환
-     * - SecurityContextHolder에서 인증 객체를 가져와서 Member 객체로 변환하여 반환
+     * - SecurityContextHolder에서 인증 객체를 가져와서 User 객체로 변환하여 반환
      */
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {

--- a/src/main/java/treehouse/server/global/security/handler/annotation/resolver/AuthMemberArgumentResolver.java
+++ b/src/main/java/treehouse/server/global/security/handler/annotation/resolver/AuthMemberArgumentResolver.java
@@ -1,0 +1,62 @@
+package treehouse.server.global.security.handler.annotation.resolver;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import treehouse.server.api.user.business.UserMapper;
+import treehouse.server.api.user.business.UserService;
+import treehouse.server.global.entity.User.User;
+import treehouse.server.global.exception.GlobalErrorCode;
+import treehouse.server.global.exception.ThrowClass.GeneralException;
+import treehouse.server.global.security.handler.annotation.AuthMember;
+
+@Component
+@RequiredArgsConstructor
+public class AuthMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    /**
+     * supportsParameter
+     * - 해당 파라미터를 지원하는지 여부를 반환
+     * - AuthMember 어노테이션이 없거나, Member 타입이 아닌 경우 false 반환
+     */
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        AuthMember authUser = parameter.getParameterAnnotation(AuthMember.class); // 메서드 파라미터에서 @AuthMember 찾기
+        if (authUser == null) return false;
+        if (parameter.getParameterType().equals(User.class) == false) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * resolveArgument
+     * 실제로 파라미터의 값을 해석해주는 메서드
+     *  파라미터에 전달할 객체를 반환
+     * - SecurityContextHolder에서 인증 객체를 가져와서 Member 객체로 변환하여 반환
+     */
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        Object principal = null;
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication != null) {
+            principal = authentication.getPrincipal();
+        }
+        if (principal == null || principal.getClass() == String.class) { //Authentication 객체가 null이거나, principal이 String 타입('anonymousUser')인 경우
+            throw new GeneralException(GlobalErrorCode.MEMBER_NOT_FOUND);
+        }
+
+        UsernamePasswordAuthenticationToken authenticationToken = (UsernamePasswordAuthenticationToken) authentication;
+
+        User user = UserMapper.toUserSecurity(authenticationToken.getName());
+        return user;
+    }
+}


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
시큐리티 세팅 및 Invitation 관련 로직 추가, 초대장 조회 API 구현
## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- AuthMember 어노테이션 관련 세팅 추가
- 초대장 조회 API 구현

## ⏳ 작업 내용
- [x] AuthMember 어노테이션 관련 세팅
- [x] Invitation 관련 로직 개발
- [x] 로그인 후 Security 관련 세팅 추가
- [x] 초대장 조회 API 구현

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

