### PR TITLE
Feat: 피드(게시글 목록) 조회 API

### DIFF
--- a/src/main/java/treehouse/server/api/post/business/PostMapper.java
+++ b/src/main/java/treehouse/server/api/post/business/PostMapper.java
@@ -2,6 +2,7 @@ package treehouse.server.api.post.business;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
 import treehouse.server.api.post.presentation.dto.PostRequestDTO;
 import treehouse.server.api.post.presentation.dto.PostResponseDTO;
 import treehouse.server.api.member.business.MemberMapper;
@@ -55,5 +56,21 @@ public class PostMapper {
         return PostResponseDTO.createPostResult.builder()
                 .postId(post.getId())
                 .build();
+    }
+
+    public static List<PostResponseDTO.getPostDetails> toGetPostList(Page<Post> postsPage) {
+        return postsPage.getContent().stream()
+                .map(post -> PostResponseDTO.getPostDetails.builder()
+                        .memberProfile(MemberMapper.toGetMemberProfile(post.getWriter()))
+                        .postId(post.getId())
+                        .context(post.getContent())
+                        .pictureUrlList(post.getPostImageList().stream()
+                                .map(PostImage::getImageUrl).toList()
+                        )
+                        .commentCount(post.getCommentList().size())
+//                        .reactionList() // Reaction 기능 개발 이후 수정
+                        .postedAt(TimeFormatter.format(post.getCreatedAt()))
+                        .build())
+                .toList();
     }
 }

--- a/src/main/java/treehouse/server/api/post/business/PostMapper.java
+++ b/src/main/java/treehouse/server/api/post/business/PostMapper.java
@@ -58,19 +58,4 @@ public class PostMapper {
                 .build();
     }
 
-    public static List<PostResponseDTO.getPostDetails> toGetPostList(Page<Post> postsPage) {
-        return postsPage.getContent().stream()
-                .map(post -> PostResponseDTO.getPostDetails.builder()
-                        .memberProfile(MemberMapper.toGetMemberProfile(post.getWriter()))
-                        .postId(post.getId())
-                        .context(post.getContent())
-                        .pictureUrlList(post.getPostImageList().stream()
-                                .map(PostImage::getImageUrl).toList()
-                        )
-                        .commentCount(post.getCommentList().size())
-//                        .reactionList() // Reaction 기능 개발 이후 수정
-                        .postedAt(TimeFormatter.format(post.getCreatedAt()))
-                        .build())
-                .toList();
-    }
 }

--- a/src/main/java/treehouse/server/api/post/business/PostMapper.java
+++ b/src/main/java/treehouse/server/api/post/business/PostMapper.java
@@ -27,6 +27,7 @@ public class PostMapper {
                 .pictureUrlList(post.getPostImageList().stream()
                         .map(PostImage::getImageUrl).toList()
                 )
+                .commentCount(post.getCommentList().size())
 //                .reactionList() // Reaction 기능 개발 이후 수정
                 .postedAt(TimeFormatter.format(post.getCreatedAt()))
                 .build();

--- a/src/main/java/treehouse/server/api/post/business/PostService.java
+++ b/src/main/java/treehouse/server/api/post/business/PostService.java
@@ -21,6 +21,7 @@ import treehouse.server.global.entity.post.PostImage;
 import treehouse.server.global.entity.treeHouse.TreeHouse;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @AllArgsConstructor
@@ -79,6 +80,10 @@ public class PostService {
         Pageable pageable = PageRequest.of(page, 10);
         Page<Post> postsPage = postQueryAdapter.findAllByTreehouse(treehouse, pageable);
 
-        return PostMapper.toGetPostList(postsPage);
+        List<PostResponseDTO.getPostDetails> postDtos = postsPage.getContent().stream()
+                .map(PostMapper::toGetPostDetails)
+                .collect(Collectors.toList());
+
+        return postDtos;
     }
 }

--- a/src/main/java/treehouse/server/api/post/business/PostService.java
+++ b/src/main/java/treehouse/server/api/post/business/PostService.java
@@ -2,6 +2,9 @@ package treehouse.server.api.post.business;
 
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import treehouse.server.api.member.implementation.MemberQueryAdapter;
@@ -68,16 +71,14 @@ public class PostService {
      * @return List<PostResponseDTO.getPostDetails>
      */
     @Transactional(readOnly = true)
-    public List<PostResponseDTO.getPostDetails> getPosts(User user, Long treehouseId){
+    public List<PostResponseDTO.getPostDetails> getPosts(User user, Long treehouseId, int page){
         // TODO 신고한 게시물과 탈퇴 및 차단한 작성자의 게시물은 제외하는 로직 추가
 
         TreeHouse treehouse = treehouseQueryAdapter.getTreehouseById(treehouseId);
 
-        List<Post> posts = postQueryAdapter.findAllByTreehouse(treehouse);
-        List<PostResponseDTO.getPostDetails> postDtos = posts.stream()
-                .map(post -> PostMapper.toGetPostDetails(post))
-                .toList();
+        Pageable pageable = PageRequest.of(page, 10);
+        Page<Post> postsPage = postQueryAdapter.findAllByTreehouse(treehouse, pageable);
 
-        return postDtos;
+        return PostMapper.toGetPostList(postsPage);
     }
 }

--- a/src/main/java/treehouse/server/api/post/business/PostService.java
+++ b/src/main/java/treehouse/server/api/post/business/PostService.java
@@ -60,4 +60,24 @@ public class PostService {
         postImageCommandAdapter.savePostImageList(postImageList);
         return PostMapper.toCreatePostResult(postCommandAdapter.savePost(post));
     }
+
+    /**
+     * 게시글 목록 조회
+     * @param user
+     * @param treehouseId - 게시글 정보에 표시할 memberBranch을 계산하고 감정표현의 isPushed 상태를 반환하기 위해 user와 treehouseId 사용
+     * @return List<PostResponseDTO.getPostDetails>
+     */
+    @Transactional(readOnly = true)
+    public List<PostResponseDTO.getPostDetails> getPosts(User user, Long treehouseId){
+        // TODO 신고한 게시물과 탈퇴 및 차단한 작성자의 게시물은 제외하는 로직 추가
+
+        TreeHouse treehouse = treehouseQueryAdapter.getTreehouseById(treehouseId);
+
+        List<Post> posts = postQueryAdapter.findAllByTreehouse(treehouse);
+        List<PostResponseDTO.getPostDetails> postDtos = posts.stream()
+                .map(post -> PostMapper.toGetPostDetails(post))
+                .toList();
+
+        return postDtos;
+    }
 }

--- a/src/main/java/treehouse/server/api/post/implement/PostQueryAdapter.java
+++ b/src/main/java/treehouse/server/api/post/implement/PostQueryAdapter.java
@@ -4,8 +4,11 @@ import lombok.RequiredArgsConstructor;
 import treehouse.server.api.post.persistence.PostRepository;
 import treehouse.server.global.annotations.Adapter;
 import treehouse.server.global.entity.post.Post;
+import treehouse.server.global.entity.treeHouse.TreeHouse;
 import treehouse.server.global.exception.GlobalErrorCode;
 import treehouse.server.global.exception.ThrowClass.PostException;
+
+import java.util.List;
 
 @Adapter
 @RequiredArgsConstructor
@@ -15,5 +18,9 @@ public class PostQueryAdapter {
 
     public Post findById(Long postId) {
         return postRepository.findById(postId).orElseThrow(() -> new PostException(GlobalErrorCode.POST_NOT_FOUND));
+    }
+
+    public List<Post> findAllByTreehouse(TreeHouse treehouse) {
+        return postRepository.findAllByTreeHouse(treehouse);
     }
 }

--- a/src/main/java/treehouse/server/api/post/implement/PostQueryAdapter.java
+++ b/src/main/java/treehouse/server/api/post/implement/PostQueryAdapter.java
@@ -1,6 +1,8 @@
 package treehouse.server.api.post.implement;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import treehouse.server.api.post.persistence.PostRepository;
 import treehouse.server.global.annotations.Adapter;
 import treehouse.server.global.entity.post.Post;
@@ -8,7 +10,6 @@ import treehouse.server.global.entity.treeHouse.TreeHouse;
 import treehouse.server.global.exception.GlobalErrorCode;
 import treehouse.server.global.exception.ThrowClass.PostException;
 
-import java.util.List;
 
 @Adapter
 @RequiredArgsConstructor
@@ -20,7 +21,7 @@ public class PostQueryAdapter {
         return postRepository.findById(postId).orElseThrow(() -> new PostException(GlobalErrorCode.POST_NOT_FOUND));
     }
 
-    public List<Post> findAllByTreehouse(TreeHouse treehouse) {
-        return postRepository.findAllByTreeHouse(treehouse);
+    public Page<Post> findAllByTreehouse(TreeHouse treehouse, Pageable pageable) {
+        return postRepository.findAllByTreeHouse(treehouse, pageable);
     }
 }

--- a/src/main/java/treehouse/server/api/post/persistence/PostRepository.java
+++ b/src/main/java/treehouse/server/api/post/persistence/PostRepository.java
@@ -2,6 +2,10 @@ package treehouse.server.api.post.persistence;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import treehouse.server.global.entity.post.Post;
+import treehouse.server.global.entity.treeHouse.TreeHouse;
+
+import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+    List<Post> findAllByTreeHouse(TreeHouse treehouse);
 }

--- a/src/main/java/treehouse/server/api/post/persistence/PostRepository.java
+++ b/src/main/java/treehouse/server/api/post/persistence/PostRepository.java
@@ -1,11 +1,12 @@
 package treehouse.server.api.post.persistence;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import treehouse.server.global.entity.post.Post;
 import treehouse.server.global.entity.treeHouse.TreeHouse;
 
-import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
-    List<Post> findAllByTreeHouse(TreeHouse treehouse);
+    Page<Post> findAllByTreeHouse(TreeHouse treehouse, Pageable pageable);
 }

--- a/src/main/java/treehouse/server/api/post/presentation/PostApi.java
+++ b/src/main/java/treehouse/server/api/post/presentation/PostApi.java
@@ -51,8 +51,9 @@ public class PostApi {
     @Operation(summary = "게시글 목록 조회 🔑", description = "트리하우스의 게시글 목록을 조회합니다.")
     public CommonResponse<List<PostResponseDTO.getPostDetails>> getPosts(
             @PathVariable Long treehouseId,
+            @RequestParam(defaultValue = "0") int page,
             @AuthMember @Parameter(hidden = true) User user
     ){
-        return CommonResponse.onSuccess(postService.getPosts(user, treehouseId));
+        return CommonResponse.onSuccess(postService.getPosts(user, treehouseId, page));
     }
 }

--- a/src/main/java/treehouse/server/api/post/presentation/PostApi.java
+++ b/src/main/java/treehouse/server/api/post/presentation/PostApi.java
@@ -15,6 +15,8 @@ import treehouse.server.global.common.CommonResponse;
 import treehouse.server.global.entity.User.User;
 import treehouse.server.global.security.handler.annotation.AuthMember;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @Slf4j
@@ -35,7 +37,7 @@ public class PostApi {
         return CommonResponse.onSuccess(postService.getPostDetails(user, postId, treehouseId));
     }
 
-    @PostMapping("/")
+    @PostMapping("/posts")
     @Operation(summary = "게시글 작성 🔑", description = "게시글 작성 API 입니다.")
     public CommonResponse<PostResponseDTO.createPostResult> createPost(
             @PathVariable(name = "treehouseId") Long treehouseId,
@@ -43,5 +45,14 @@ public class PostApi {
             @AuthMember @Parameter(hidden = true) User user
     ){
         return CommonResponse.onSuccess(postService.createPost(user,request, treehouseId));
+    }
+
+    @GetMapping
+    @Operation(summary = "게시글 목록 조회 🔑", description = "트리하우스의 게시글 목록을 조회합니다.")
+    public CommonResponse<List<PostResponseDTO.getPostDetails>> getPosts(
+            @PathVariable Long treehouseId,
+            @AuthMember @Parameter(hidden = true) User user
+    ){
+        return CommonResponse.onSuccess(postService.getPosts(user, treehouseId));
     }
 }

--- a/src/main/java/treehouse/server/api/post/presentation/dto/PostResponseDTO.java
+++ b/src/main/java/treehouse/server/api/post/presentation/dto/PostResponseDTO.java
@@ -21,6 +21,7 @@ public class PostResponseDTO {
         private Long postId;
         private String context;
         private List<String> pictureUrlList;
+        private Integer commentCount;
 //        private List<ReactionResponseDto.getReaction> reactionList; Reaction 기능 개발 이후 적용
         private String postedAt;
     }
@@ -36,4 +37,5 @@ public class PostResponseDTO {
         @JsonProperty("postId")
         private Long postId;
     }
+
 }

--- a/src/main/java/treehouse/server/global/entity/comment/Comment.java
+++ b/src/main/java/treehouse/server/global/entity/comment/Comment.java
@@ -20,7 +20,7 @@ public class Comment extends BaseDateTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Member writer;
 
-    @JoinColumn(name = "feedId")
+    @JoinColumn(name = "postId")
     @ManyToOne(fetch = FetchType.LAZY)
     private Post post;
 }

--- a/src/main/java/treehouse/server/global/exception/GlobalErrorCode.java
+++ b/src/main/java/treehouse/server/global/exception/GlobalErrorCode.java
@@ -12,7 +12,7 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 @RequiredArgsConstructor
 public enum GlobalErrorCode implements BaseErrorCode{
 
-    // 401 Unauthorized - 권한 없음
+    // AUTH + 401 Unauthorized - 권한 없음
     TOKEN_EXPIRED(UNAUTHORIZED, "AUTH401_1", "인증 토큰이 만료 되었습니다. 토큰을 재발급 해주세요"),
     INVALID_TOKEN(UNAUTHORIZED, "AUTH401_2", "인증 토큰이 유효하지 않습니다."),
     INVALID_REFRESH_TOKEN(UNAUTHORIZED, "AUTH401_3", "리프레시 토큰이 유효하지 않습니다."),
@@ -20,68 +20,61 @@ public enum GlobalErrorCode implements BaseErrorCode{
     AUTHENTICATION_REQUIRED(UNAUTHORIZED, "AUTH401_5", "인증 정보가 유효하지 않습니다."),
     LOGIN_REQUIRED(UNAUTHORIZED, "AUTH401_6", "로그인이 필요한 서비스입니다."),
 
-    // 403 Forbidden - 인증 거부
+    // AUTH + 403 Forbidden - 인증 거부
     AUTHENTICATION_DENIED(FORBIDDEN, "AUTH403_1", "인증이 거부 되었습니다."),
 
-    // 404 Not Found - 찾을 수 없음
+    // AUTH + 404 Not Found - 찾을 수 없음
     REFRESH_TOKEN_NOT_FOUND(NOT_FOUND, "AUTH404_1", "리프레시 토큰이 존재하지 않습니다."),
 
-    // 500 Server Error
+    // GLOBAL + 500 Server Error
     SERVER_ERROR(INTERNAL_SERVER_ERROR, "GLOBAL500_1", "서버 에러, 서버 개발자에게 알려주세요."),
 
-    // Args Validation Error
+    // GLOBAL + Args Validation Error
     BAD_ARGS_ERROR(BAD_REQUEST, "GLOBAL400_1", "request body의 validation이 실패했습니다. 응답 body를 참고해주세요"),
 
-    //  Member
-    // 400 BAD_REQUEST - 잘못된 요청
+    // USER + 400 BAD_REQUEST - 잘못된 요청
     NOT_VALID_PHONE_NUMBER(BAD_REQUEST, "USER400_1", "유효하지 않은 전화번호 입니다."),
 
-    // 401 Unauthorized - 권한 없음
+    // USER + 401 Unauthorized - 권한 없음
 
-    // 403 Forbidden - 인증 거부
+    // USER + 403 Forbidden - 인증 거부
 
-    // 404 Not Found - 찾을 수 없음
+    // USER + 404 Not Found - 찾을 수 없음
     MEMBER_NOT_FOUND(NOT_FOUND, "USER404_1", "등록된 사용자 정보가 없습니다."),
 
-
-    // 409 CONFLICT : Resource 를 찾을 수 없음
+    // USER + 409 CONFLICT : Resource 를 찾을 수 없음
     DUPLICATE_PHONE_NUMBER(CONFLICT, "USER409_1", "중복된 전화번호가 존재합니다."),
 
-    //Profile
-    //404 Not Found - 찾을 수 없음
+    // MEMBER + 404 Not Found - 찾을 수 없음
     PROFILE_NOT_FOUND(NOT_FOUND, "MEMBER404_1", "존재하지 않는 프로필입니다."),
     AVAILABLE_PROFILE_NOT_FOUND(NOT_FOUND, "MEMBER404_2", "현재 선택된 프로필이 없습니다."),
 
-    //Treehouse
-    //404 Not Found - 찾을 수 없음
+    // TREEHOUSE + 404 Not Found - 찾을 수 없음
     TREEHOUSE_NOT_FOUND(NOT_FOUND, "TREEHOUSE404_1", "존재하지 않는 트리입니다."),
 
-    //Invitation
-    //404 Not Found - 찾을 수 없음
+    // INVITATION + 404 Not Found - 찾을 수 없음
     INVITATION_NOT_FOUND(NOT_FOUND, "INVITATION404_1", "존재하지 않는 초대장입니다."),
 
-    //Post
-    //404 Not Found - 찾을 수 없음
+    // POST + 404 Not Found - 찾을 수 없음
     POST_NOT_FOUND(NOT_FOUND, "POST404_1", "존재하지 않는 게시글입니다."),
 
-    //Comment
-    //404 Not Found - 찾을 수 없음
+    // COMMENT + 404 Not Found - 찾을 수 없음
     COMMENT_NOT_FOUND(NOT_FOUND, "COMMENT404_1", "존재하지 않는 댓글입니다."),
 
-    //Reply
-    //404 Not Found - 찾을 수 없음
+    // REPLY + 404 Not Found - 찾을 수 없음
     REPLY_NOT_FOUND(NOT_FOUND, "REPLY404_1", "존재하지 않는 답글입니다."),
 
-    //Branch
-    //404 Not Found - 찾을 수 없음
+    // BRANCH + 404 Not Found - 찾을 수 없음
     BRANCH_NOT_FOUND(NOT_FOUND, "BRANCH404_1", "브랜치 정보를 찾을 수 없습니다."),
 
-    //Notification
-    //404 Not Found - 찾을 수 없음
+
+    // NOTIFICATION + 404 Not Found - 찾을 수 없음
     NOTIFICATION_NOT_FOUND(NOT_FOUND, "NOTIFICATION", "존재하지 않는 알림입니다."),
 
-    //FeignClient
+    //FEIGN + 400 BAD_REQUEST - 잘못된 요청
     FEIGN_CLIENT_ERROR_400(BAD_REQUEST, "FEIGN400", "feignClient 에서 400번대 에러가 발생했습니다."),
+
+    //FEIGN + 500 INTERNAL_SERVER_ERROR - 서버 에러
     FEIGN_CLIENT_ERROR_500(INTERNAL_SERVER_ERROR, "FEIGN500", "feignClient 에서 500번대 에러가 발생했습니다."),
 
     // NCP Phone Auth


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
피드(게시글 목록) 조회하는 API의 구현

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 피드(게시글 목록) 조회하는 API의 구현
- 특정 Treehouse에 작성된 모든 게시글을 불러오는 메서드 `findAllByTreehouse` 작성
- PostResopnseDTO.getPostDetails에 특정 게시글에 달린 댓글의 개수를 나타내는 `commentCount` 추가

## ⏳ 작업 내용
- [x] **GET** /treehouses/{treehouseId}/feeds

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
신고한 게시물과 탈퇴 및 차단한 사용자가 작성한 게시물은 제외하는 로직을 추가할 예정입니다.
감정표현(리액션) 기능 구현 이후 reactionList 필드 추가할 예정입니다,
