### PR TITLE
Feature/37 - 게시글 수정/삭제 API 구현

### DIFF
--- a/src/main/java/treehouse/server/api/member/implementation/MemberQueryAdapter.java
+++ b/src/main/java/treehouse/server/api/member/implementation/MemberQueryAdapter.java
@@ -5,6 +5,7 @@ import treehouse.server.api.member.persistence.MemberRepository;
 import treehouse.server.global.annotations.Adapter;
 import treehouse.server.global.entity.User.User;
 import treehouse.server.global.entity.member.Member;
+import treehouse.server.global.entity.treeHouse.TreeHouse;
 import treehouse.server.global.exception.GlobalErrorCode;
 import treehouse.server.global.exception.ThrowClass.MemberException;
 
@@ -16,6 +17,10 @@ public class MemberQueryAdapter {
 
     public Member getMember(User user){
 
-        return memberRepository.findByUser(user).orElseThrow(()-> new MemberException(GlobalErrorCode.MEMBER_NOT_FOUND));
+        return memberRepository.findByUser(user).orElseThrow(()-> new MemberException(GlobalErrorCode.USER_NOT_FOUND));
+    }
+
+    public Member findByUserAndTreehouse(User user, TreeHouse treehouse) {
+        return memberRepository.findByUserAndTreeHouse(user, treehouse).orElseThrow(() -> new MemberException(GlobalErrorCode.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/treehouse/server/api/member/persistence/MemberRepository.java
+++ b/src/main/java/treehouse/server/api/member/persistence/MemberRepository.java
@@ -3,10 +3,13 @@ package treehouse.server.api.member.persistence;
 import org.springframework.data.jpa.repository.JpaRepository;
 import treehouse.server.global.entity.User.User;
 import treehouse.server.global.entity.member.Member;
+import treehouse.server.global.entity.treeHouse.TreeHouse;
 
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     public Optional<Member> findByUser(User user);
+
+    Optional<Member> findByUserAndTreeHouse(User user, TreeHouse treehouse);
 }

--- a/src/main/java/treehouse/server/api/post/business/PostMapper.java
+++ b/src/main/java/treehouse/server/api/post/business/PostMapper.java
@@ -2,12 +2,10 @@ package treehouse.server.api.post.business;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.springframework.data.domain.Page;
 import treehouse.server.api.post.presentation.dto.PostRequestDTO;
 import treehouse.server.api.post.presentation.dto.PostResponseDTO;
 import treehouse.server.api.member.business.MemberMapper;
 import treehouse.server.global.common.TimeFormatter;
-import treehouse.server.global.entity.User.User;
 import treehouse.server.global.entity.member.Member;
 import treehouse.server.global.entity.post.Post;
 import treehouse.server.global.entity.post.PostImage;
@@ -60,6 +58,12 @@ public class PostMapper {
         return PostResponseDTO.createPresignedUrlResult.builder()
                 .uploadUrl(result.getUploadUrl())
                 .accessUrl(result.getDownloadUrl())
+                .build();
+    }
+
+    public static PostResponseDTO.updatePostResult toUpdatePostResult(Post post) {
+        return PostResponseDTO.updatePostResult.builder()
+                .postId(post.getId())
                 .build();
     }
 }

--- a/src/main/java/treehouse/server/api/post/business/PostMapper.java
+++ b/src/main/java/treehouse/server/api/post/business/PostMapper.java
@@ -16,19 +16,16 @@ import treehouse.server.global.feign.dto.PresignedUrlDTO;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class PostMapper {
 
-    public static PostResponseDTO.getPostDetails toGetPostDetails(Post post) {
+    public static PostResponseDTO.getPostDetails toGetPostDetails(Post post, List<String> postImageUrlList) {
         return PostResponseDTO.getPostDetails.builder()
                 .memberProfile(MemberMapper.toGetMemberProfile(post.getWriter()))
                 .postId(post.getId())
                 .context(post.getContent())
-                .pictureUrlList(post.getPostImageList().stream()
-                        .map(PostImage::getImageUrl).toList()
-                )
+                .pictureUrlList(postImageUrlList)
                 .commentCount(post.getCommentList().size())
 //                .reactionList() // Reaction 기능 개발 이후 수정
                 .postedAt(TimeFormatter.format(post.getCreatedAt()))

--- a/src/main/java/treehouse/server/api/post/business/PostService.java
+++ b/src/main/java/treehouse/server/api/post/business/PostService.java
@@ -119,4 +119,19 @@ public class PostService {
 
         return postDtos;
     }
+
+    @Transactional
+    public PostResponseDTO.updatePostResult updatePost(User user, Long postId, PostRequestDTO.updatePost request) {
+        Post post = postQueryAdapter.findById(postId);
+        //TODO 게시글 작성자와 현재 로그인 한 사용자가 같은지 확인하는 로직 추가
+        post.update(request.getContext());
+        return PostMapper.toUpdatePostResult(postCommandAdapter.savePost(post));
+    }
+
+    @Transactional
+    public void deletePost(User user, Long postId) {
+        Post post = postQueryAdapter.findById(postId);
+        //TODO 게시글 작성자와 현재 로그인 한 사용자가 같은지 확인하는 로직 추가
+        postCommandAdapter.deletePost(post);
+    }
 }

--- a/src/main/java/treehouse/server/api/post/implement/PostCommandAdapter.java
+++ b/src/main/java/treehouse/server/api/post/implement/PostCommandAdapter.java
@@ -17,4 +17,7 @@ public class PostCommandAdapter {
         return postRepository.save(post);
     }
 
+    public void deletePost(Post post) {
+        postRepository.delete(post);
+    }
 }

--- a/src/main/java/treehouse/server/api/post/presentation/PostApi.java
+++ b/src/main/java/treehouse/server/api/post/presentation/PostApi.java
@@ -75,7 +75,7 @@ public class PostApi {
             @RequestBody @Valid PostRequestDTO.updatePost request,
             @AuthMember @Parameter(hidden = true) User user
     ){
-        return CommonResponse.onSuccess(postService.updatePost(user, postId, request));
+        return CommonResponse.onSuccess(postService.updatePost(user, treehouseId, postId, request));
     }
 
     @DeleteMapping("/posts/{postId}")
@@ -85,7 +85,7 @@ public class PostApi {
             @PathVariable Long postId,
             @AuthMember @Parameter(hidden = true) User user
     ){
-        postService.deletePost(user, postId);
+        postService.deletePost(user, treehouseId, postId);
         return CommonResponse.onSuccess(null);
     }
 }

--- a/src/main/java/treehouse/server/api/post/presentation/PostApi.java
+++ b/src/main/java/treehouse/server/api/post/presentation/PostApi.java
@@ -66,4 +66,26 @@ public class PostApi {
     ){
         return CommonResponse.onSuccess(postService.getPosts(user, treehouseId, page));
     }
+
+    @PatchMapping("/posts/{postId}")
+    @Operation(summary = "게시글 수정 ✅ 🔑", description = "게시글을 수정합니다(이미지는 수정불가)")
+    public CommonResponse<PostResponseDTO.updatePostResult> updatePost(
+            @PathVariable Long treehouseId,
+            @PathVariable Long postId,
+            @RequestBody @Valid PostRequestDTO.updatePost request,
+            @AuthMember @Parameter(hidden = true) User user
+    ){
+        return CommonResponse.onSuccess(postService.updatePost(user, postId, request));
+    }
+
+    @DeleteMapping("/posts/{postId}")
+    @Operation(summary = "게시글 삭제 ✅ 🔑", description = "게시글을 삭제합니다.")
+    public CommonResponse deletePost(
+            @PathVariable Long treehouseId,
+            @PathVariable Long postId,
+            @AuthMember @Parameter(hidden = true) User user
+    ){
+        postService.deletePost(user, postId);
+        return CommonResponse.onSuccess(null);
+    }
 }

--- a/src/main/java/treehouse/server/api/post/presentation/dto/PostRequestDTO.java
+++ b/src/main/java/treehouse/server/api/post/presentation/dto/PostRequestDTO.java
@@ -39,4 +39,13 @@ public class PostRequestDTO {
         @NotNull(message = "fileSize가 필요합니다.")
         private Double fileSize;
     }
+
+    @Getter
+    public static class updatePost{
+
+        @JsonProperty("context")
+        @Schema(description = "게시글 내용", example = "게시글 내용")
+        @NotBlank(message = "게시글 내용이 필요합니다.")
+        private String context;
+    }
 }

--- a/src/main/java/treehouse/server/api/post/presentation/dto/PostResponseDTO.java
+++ b/src/main/java/treehouse/server/api/post/presentation/dto/PostResponseDTO.java
@@ -54,4 +54,14 @@ public class PostResponseDTO {
         @JsonProperty("accessUrl")
         private String accessUrl;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class updatePostResult {
+
+        @Schema(description = "수정 된 포스트 ID", example = "1")
+        private Long postId;
+    }
 }

--- a/src/main/java/treehouse/server/api/user/business/UserService.java
+++ b/src/main/java/treehouse/server/api/user/business/UserService.java
@@ -9,7 +9,6 @@ import treehouse.server.api.user.implement.UserQueryAdapter;
 import treehouse.server.api.user.presentation.dto.UserRequestDTO;
 import treehouse.server.api.user.presentation.dto.UserResponseDTO;
 import treehouse.server.global.entity.User.User;
-import treehouse.server.global.entity.member.Member;
 import treehouse.server.global.entity.redis.RefreshToken;
 import treehouse.server.global.exception.GlobalErrorCode;
 import treehouse.server.global.exception.ThrowClass.AuthException;
@@ -54,7 +53,7 @@ public class UserService {
     @Transactional
     public UserResponseDTO.registerUser login(UserRequestDTO.loginMember request){
         User user = userQueryAdapter.findByPhoneNumber(request.getPhoneNumber())
-                .orElseThrow(() -> new GeneralException(GlobalErrorCode.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(GlobalErrorCode.USER_NOT_FOUND));
         TokenDTO loginResult = userCommandAdapter.login(user);
 
         return UserMapper.toRegister(user,loginResult.getAccessToken(), loginResult.getRefreshToken());

--- a/src/main/java/treehouse/server/api/user/implement/UserQueryAdapter.java
+++ b/src/main/java/treehouse/server/api/user/implement/UserQueryAdapter.java
@@ -31,7 +31,7 @@ public class UserQueryAdapter {
     }
 
     public User findById(Long id){
-        return userRepository.findById(id).orElseThrow(()->new UserException(GlobalErrorCode.MEMBER_NOT_FOUND));
+        return userRepository.findById(id).orElseThrow(()->new UserException(GlobalErrorCode.USER_NOT_FOUND));
     }
 
     public Optional<User> optionalUserFindById(Long id){

--- a/src/main/java/treehouse/server/global/entity/post/Post.java
+++ b/src/main/java/treehouse/server/global/entity/post/Post.java
@@ -29,10 +29,10 @@ public class Post extends BaseDateTimeEntity {
 
     private String content;
 
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Comment> commentList;
 
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<PostImage> postImageList;
 
     public void update(String context) {

--- a/src/main/java/treehouse/server/global/entity/post/Post.java
+++ b/src/main/java/treehouse/server/global/entity/post/Post.java
@@ -34,4 +34,8 @@ public class Post extends BaseDateTimeEntity {
 
     @OneToMany(mappedBy = "post")
     private List<PostImage> postImageList;
+
+    public void update(String context) {
+        this.content = context;
+    }
 }

--- a/src/main/java/treehouse/server/global/exception/GeneralExceptionHandler.java
+++ b/src/main/java/treehouse/server/global/exception/GeneralExceptionHandler.java
@@ -19,8 +19,6 @@ import treehouse.server.global.common.CommonResponse;
 import treehouse.server.global.exception.ThrowClass.GeneralException;
 import treehouse.server.global.exception.dto.ErrorResponseDTO;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -29,11 +27,11 @@ import java.util.Optional;
 @RestControllerAdvice(annotations = {RestController.class})
 public class GeneralExceptionHandler extends ResponseEntityExceptionHandler {
 
-//    @ExceptionHandler(value = { GeneralException.class})
-//    protected ApiResponse handleCustomException(GeneralException e) {
-//        log.error("handleCustomException throw CustomException : {}", e.getErrorCode());
-//        return ApiResponse.onFailure(e.getErrorCode(), "");
-//    }
+    @ExceptionHandler(value = { GeneralException.class})
+    protected ResponseEntity<Object> handleCustomException(GeneralException e, HttpServletRequest request) {
+        log.error("handleCustomException throw CustomException : {}", e.getErrorCode());
+        return handleExceptionInternal(e, e.getErrorReasonHttpStatus(), HttpHeaders.EMPTY, request);
+    }
 
 
     @ExceptionHandler

--- a/src/main/java/treehouse/server/global/exception/GlobalErrorCode.java
+++ b/src/main/java/treehouse/server/global/exception/GlobalErrorCode.java
@@ -41,7 +41,7 @@ public enum GlobalErrorCode implements BaseErrorCode{
     // USER + 403 Forbidden - 인증 거부
 
     // USER + 404 Not Found - 찾을 수 없음
-    MEMBER_NOT_FOUND(NOT_FOUND, "USER404_1", "등록된 사용자 정보가 없습니다."),
+    USER_NOT_FOUND(NOT_FOUND, "USER404_1", "등록된 사용자 정보가 없습니다."),
 
     // USER + 409 CONFLICT : Resource 를 찾을 수 없음
     DUPLICATE_PHONE_NUMBER(CONFLICT, "USER409_1", "중복된 전화번호가 존재합니다."),
@@ -56,6 +56,8 @@ public enum GlobalErrorCode implements BaseErrorCode{
     // INVITATION + 404 Not Found - 찾을 수 없음
     INVITATION_NOT_FOUND(NOT_FOUND, "INVITATION404_1", "존재하지 않는 초대장입니다."),
 
+    // POST + 401 Unauthorized - 권한 없음
+    POST_UNAUTHORIZED(UNAUTHORIZED, "POST401_1", "게시글 수정 및 삭제 권한이 없습니다."),
     // POST + 404 Not Found - 찾을 수 없음
     POST_NOT_FOUND(NOT_FOUND, "POST404_1", "존재하지 않는 게시글입니다."),
 

--- a/src/main/java/treehouse/server/global/redis/service/RedisService.java
+++ b/src/main/java/treehouse/server/global/redis/service/RedisService.java
@@ -33,7 +33,7 @@ public class RedisService {
      */
     public RefreshToken generateRefreshToken(User user) {
         if (!userQueryAdapter.existById(user.getId()))
-            throw new GeneralException(GlobalErrorCode.MEMBER_NOT_FOUND);
+            throw new GeneralException(GlobalErrorCode.USER_NOT_FOUND);
 
         String refreshToken = tokenProvider.createRefreshToken();
 

--- a/src/main/java/treehouse/server/global/security/handler/annotation/resolver/AuthMemberArgumentResolver.java
+++ b/src/main/java/treehouse/server/global/security/handler/annotation/resolver/AuthMemberArgumentResolver.java
@@ -11,7 +11,6 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 import treehouse.server.api.user.business.UserMapper;
-import treehouse.server.api.user.business.UserService;
 import treehouse.server.global.entity.User.User;
 import treehouse.server.global.exception.GlobalErrorCode;
 import treehouse.server.global.exception.ThrowClass.GeneralException;
@@ -51,7 +50,7 @@ public class AuthMemberArgumentResolver implements HandlerMethodArgumentResolver
             principal = authentication.getPrincipal();
         }
         if (principal == null || principal.getClass() == String.class) { //Authentication 객체가 null이거나, principal이 String 타입('anonymousUser')인 경우
-            throw new GeneralException(GlobalErrorCode.MEMBER_NOT_FOUND);
+            throw new GeneralException(GlobalErrorCode.USER_NOT_FOUND);
         }
 
         UsernamePasswordAuthenticationToken authenticationToken = (UsernamePasswordAuthenticationToken) authentication;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
 ---
 spring:
   profiles:
-    active: dev
+    active: local
   servlet:
     multipart:
       maxFileSize: 10MB

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
 ---
 spring:
   profiles:
-    active: local
+    active: dev
   servlet:
     multipart:
       maxFileSize: 10MB

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -108,6 +108,12 @@ spring:
     password: ${aws.db.password}
     url: jdbc:mysql://${aws.db.url}/${aws.db.name}?autoReconnect=true&setTimezone=Asia/Seoul
     driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 5
+      connection-timeout: 30000
+      idle-timeout: 600000
+      max-lifetime: 1800000
   sql:
     init:
       mode: never


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
게시글 수정/삭제 API 구현

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- PostMapper.getPostDetails에서 jpa 쿼리를 보내지 않고, PostService에서 보내 게시글 이미지의 url을 Mapper로 보내도록 수정
- 게시글 수정 API 
- 게시글 삭제 API

## ⏳ 작업 내용
- [x] 게시글 수정 API 구현
- [x] 게시글 삭제 API 구현

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
수정/삭제 시, 대상 게시글의 작성자와 현재 로그인 해 있는 사용자가 동일한지 확인하는 로직을 구현하고자 하는데, 하나의 User가 여러 트리하우스에 가입해 Member를 여러개 가진 경우, 이를 어떻게 처리해야할까요? 지난번 끔찍했던 코드(getTreeProfile)가 발생한 원인이 이곳입니다.
