### PR TITLE
Refactor: 기존 유저 로그인 API 수정

### DIFF
--- a/src/main/java/treehouse/server/api/member/business/MemberMapper.java
+++ b/src/main/java/treehouse/server/api/member/business/MemberMapper.java
@@ -5,17 +5,19 @@ import org.springframework.stereotype.Component;
 import treehouse.server.api.member.presentation.dto.MemberResponseDTO;
 import treehouse.server.global.entity.User.User;
 import treehouse.server.global.entity.member.Member;
+import treehouse.server.global.entity.treeHouse.TreeHouse;
 
 @Component
 @RequiredArgsConstructor
 public class MemberMapper {
 
-    public static Member toMember(User user, String memberName, String bio, String profileImageUrl) {
+    public static Member toMember(User user, String memberName, String bio, String profileImageUrl, TreeHouse treeHouse) {
         return Member.builder()
                 .user(user)
                 .name(memberName)
                 .bio(bio)
                 .profileImageUrl(profileImageUrl)
+                .treeHouse(treeHouse)
                 .build();
     }
 

--- a/src/main/java/treehouse/server/api/member/business/MemberService.java
+++ b/src/main/java/treehouse/server/api/member/business/MemberService.java
@@ -8,8 +8,10 @@ import treehouse.server.api.member.implementation.MemberCommandAdapter;
 import treehouse.server.api.member.implementation.MemberQueryAdapter;
 import treehouse.server.api.member.presentation.dto.MemberRequestDTO;
 import treehouse.server.api.member.presentation.dto.MemberResponseDTO;
+import treehouse.server.api.treehouse.implementation.TreehouseQueryAdapter;
 import treehouse.server.global.entity.User.User;
 import treehouse.server.global.entity.member.Member;
+import treehouse.server.global.entity.treeHouse.TreeHouse;
 
 @Service
 @AllArgsConstructor
@@ -19,6 +21,7 @@ public class MemberService {
     private final MemberQueryAdapter memberQueryAdapter;
 
     private final MemberCommandAdapter memberCommandAdapter;
+    private final TreehouseQueryAdapter treehouseQueryAdapter;
 
     /**
      * 회원가입
@@ -28,8 +31,9 @@ public class MemberService {
      */
     @Transactional
     public MemberResponseDTO.registerMember register(User user, MemberRequestDTO.registerMember request){
+        TreeHouse treeHouse = treehouseQueryAdapter.getTreehouseById(request.getTreehouseId());
         Member member = MemberMapper.toMember(user, request.getMemberName(),
-                                                request.getBio(), request.getProfileImageURL());
+                                                request.getBio(), request.getProfileImageURL(), treeHouse);
         Member savedMember = memberCommandAdapter.register(member);
 
         return MemberMapper.toRegister(request.getTreehouseId(), savedMember); // treehouseId는 관련 기능 구현 후 변경

--- a/src/main/java/treehouse/server/api/user/business/UserMapper.java
+++ b/src/main/java/treehouse/server/api/user/business/UserMapper.java
@@ -8,6 +8,8 @@ import treehouse.server.global.entity.User.User;
 import treehouse.server.global.entity.User.UserRole;
 import treehouse.server.global.entity.User.UserStatus;
 
+import java.util.List;
+
 @Component
 //@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @RequiredArgsConstructor
@@ -58,6 +60,15 @@ public class UserMapper {
         return UserResponseDTO.checkUserStatus.builder()
                 .isNewUser(isNewUser)
                 .isInvited(isInvited)
+                .build();
+    }
+
+    public static UserResponseDTO.loginMember toLogin(User user, String accessToken, String refreshToken, List<Long> treehouseIdList){
+        return UserResponseDTO.loginMember.builder()
+                .userId(user.getId())
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .treehouseIdList(treehouseIdList)
                 .build();
     }
 }

--- a/src/main/java/treehouse/server/api/user/implement/UserQueryAdapter.java
+++ b/src/main/java/treehouse/server/api/user/implement/UserQueryAdapter.java
@@ -26,8 +26,8 @@ public class UserQueryAdapter {
         return userRepository.existsById(id);
     }
 
-    public Optional<User> findByPhoneNumber(String phone){
-        return userRepository.findByPhone(phone);
+    public User findByPhoneNumber(String phone){
+        return userRepository.findByPhone(phone).orElseThrow(()->new UserException(GlobalErrorCode.USER_NOT_FOUND));
     }
 
     public User findById(Long id){

--- a/src/main/java/treehouse/server/api/user/presentation/UserApi.java
+++ b/src/main/java/treehouse/server/api/user/presentation/UserApi.java
@@ -48,9 +48,9 @@ public class UserApi {
         return CommonResponse.onSuccess(userService.reissue(request));
     }
 
-    @PostMapping("/login-tmp")
-    @Operation(summary = "로그인 임시", description = "로그인 임시.")
-    public CommonResponse<UserResponseDTO.registerUser> loginTemp(
+    @PostMapping("/login")
+    @Operation(summary = "로그인 ✅", description = "휴대폰 번호로 로그인합니다.")
+    public CommonResponse<UserResponseDTO.loginMember> login(
              @RequestBody final UserRequestDTO.loginMember request
     ){
         return CommonResponse.onSuccess((userService.login(request)));

--- a/src/main/java/treehouse/server/api/user/presentation/dto/UserResponseDTO.java
+++ b/src/main/java/treehouse/server/api/user/presentation/dto/UserResponseDTO.java
@@ -2,6 +2,8 @@ package treehouse.server.api.user.presentation.dto;
 
 import lombok.*;
 
+import java.util.List;
+
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class UserResponseDTO {
 
@@ -56,5 +58,17 @@ public class UserResponseDTO {
 
         Boolean isNewUser;
         Boolean isInvited;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class loginMember {
+
+        private Long userId;
+        private String accessToken;
+        private String refreshToken;
+        private List<Long> treehouseIdList;
     }
 }


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
기존 유저 로그인 API 수정

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 기존의 로그인 API 를 수정합니다
- URI: **POST** /users/login 으로 수정
- UserResponseDTO.loginMember 생성 - userId, accessToken, refreshToken, treehouseIdList(현재 가입된 트리하우스들의 id) 반환
- `MemberMapper.toMember` - 트리하우스 가입 시 Member에 TreeHouse 매핑이 제대로 되도록 수정

## ⏳ 작업 내용
- [x] **POST** /users/login 

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

