### PR TITLE
♻️ Refactor: Mapper 클래스 구조 변경과 NotificationType enum 추가

### DIFF
--- a/src/main/java/treehouse/server/api/comment/business/CommentService.java
+++ b/src/main/java/treehouse/server/api/comment/business/CommentService.java
@@ -154,8 +154,10 @@ public class CommentService {
         }
 
         Reaction reaction = ReactionMapper.toCommentReaction(request, comment, member);
+        Reaction savedReaction = reactionCommandAdapter.saveReaction(reaction);
 
-        reactionCommandAdapter.saveReaction(reaction);
+        member.addReaction(savedReaction);
+
         return request.getReactionName() + " is saved";
     }
 }

--- a/src/main/java/treehouse/server/api/member/business/MemberMapper.java
+++ b/src/main/java/treehouse/server/api/member/business/MemberMapper.java
@@ -2,29 +2,36 @@ package treehouse.server.api.member.business;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import treehouse.server.api.member.presentation.dto.MemberRequestDTO;
 import treehouse.server.api.member.presentation.dto.MemberResponseDTO;
 import treehouse.server.global.entity.User.User;
 import treehouse.server.global.entity.member.Member;
 import treehouse.server.global.entity.treeHouse.TreeHouse;
 
+import java.util.ArrayList;
+
 @Component
 @RequiredArgsConstructor
 public class MemberMapper {
 
-    public static Member toMember(User user, String memberName, String bio, String profileImageUrl, TreeHouse treeHouse) {
+    public static Member toMember(User user, MemberRequestDTO.registerMember request, TreeHouse treeHouse) {
         return Member.builder()
                 .user(user)
-                .name(memberName)
-                .bio(bio)
-                .profileImageUrl(profileImageUrl)
+                .name(request.getMemberName())
+                .bio(request.getBio())
+                .profileImageUrl(request.getProfileImageURL())
                 .treeHouse(treeHouse)
+                .notificationList(new ArrayList<>())
+                .commentList(new ArrayList<>())
+                .invitationList(new ArrayList<>())
+                .reactionList(new ArrayList<>())
                 .build();
     }
 
-    public static MemberResponseDTO.registerMember toRegister(Long treehouseId, Member member) {
+    public static MemberResponseDTO.registerMember toRegister(Member member) {
         return MemberResponseDTO.registerMember.builder()
                 .userId(member.getUser().getId())
-                .treehouseId(treehouseId) // treehouseId는 관련 기능 구현 후 변경 예정
+                .treehouseId(member.getTreeHouse().getId())
                 .build();
     }
 

--- a/src/main/java/treehouse/server/api/member/business/MemberService.java
+++ b/src/main/java/treehouse/server/api/member/business/MemberService.java
@@ -24,7 +24,7 @@ public class MemberService {
     private final TreehouseQueryAdapter treehouseQueryAdapter;
 
     /**
-     * 회원가입
+     * 트리하우스에 가입
      * @param user
      * @param request
      * @return
@@ -32,10 +32,12 @@ public class MemberService {
     @Transactional
     public MemberResponseDTO.registerMember register(User user, MemberRequestDTO.registerMember request){
         TreeHouse treeHouse = treehouseQueryAdapter.getTreehouseById(request.getTreehouseId());
-        Member member = MemberMapper.toMember(user, request.getMemberName(),
-                                                request.getBio(), request.getProfileImageURL(), treeHouse);
+        Member member = MemberMapper.toMember(user, request, treeHouse);
         Member savedMember = memberCommandAdapter.register(member);
 
-        return MemberMapper.toRegister(request.getTreehouseId(), savedMember); // treehouseId는 관련 기능 구현 후 변경
+        user.addMember(savedMember); // User에 Member 추가
+        treeHouse.addMember(savedMember); // TreeHouse에 Member 추가
+
+        return MemberMapper.toRegister(savedMember);
     }
 }

--- a/src/main/java/treehouse/server/api/post/business/PostService.java
+++ b/src/main/java/treehouse/server/api/post/business/PostService.java
@@ -242,6 +242,7 @@ public class PostService {
         Member member = memberQueryAdapter.findByUserAndTreehouse(user, treehouse);
 
         Post post = postQueryAdapter.findById(postId);
+
         Boolean isPushed = reactionQueryAdapter.existByMemberAndPostAndReactionName(member, post, request.getReactionName());
         if (isPushed) {
             reactionCommandAdapter.deletePostReaction(member, post, request.getReactionName());
@@ -249,8 +250,10 @@ public class PostService {
         }
 
         Reaction reaction = ReactionMapper.toPostReaction(request, post, member);
+        Reaction savedReaction = reactionCommandAdapter.saveReaction(reaction);
 
-        reactionCommandAdapter.saveReaction(reaction);
+        member.addReaction(savedReaction);
+
         return request.getReactionName() + " is saved";
     }
 }

--- a/src/main/java/treehouse/server/global/entity/User/User.java
+++ b/src/main/java/treehouse/server/global/entity/User/User.java
@@ -51,4 +51,7 @@ public class User extends BaseDateTimeEntity {
     @OneToMany(mappedBy = "user")
     private List<Member> memberList;
 
+    public void addMember(Member member) {
+        memberList.add(member);
+    }
 }

--- a/src/main/java/treehouse/server/global/entity/member/Member.java
+++ b/src/main/java/treehouse/server/global/entity/member/Member.java
@@ -51,5 +51,7 @@ public class Member extends BaseDateTimeEntity {
     @OneToMany(mappedBy = "member")
     List<Reaction> reactionList;
 
-
+    public void addReaction(Reaction reaction) {
+        reactionList.add(reaction);
+    }
 }

--- a/src/main/java/treehouse/server/global/entity/notification/NotificationType.java
+++ b/src/main/java/treehouse/server/global/entity/notification/NotificationType.java
@@ -1,5 +1,5 @@
 package treehouse.server.global.entity.notification;
 
 public enum NotificationType {
-    INVITATION, COMMENT, REACTION
+    INVITATION, COMMENT, REPLY, POST_REACTION, COMMENT_REACTION
 }

--- a/src/main/java/treehouse/server/global/entity/treeHouse/TreeHouse.java
+++ b/src/main/java/treehouse/server/global/entity/treeHouse/TreeHouse.java
@@ -26,4 +26,8 @@ public class TreeHouse extends BaseDateTimeEntity {
 
     @OneToMany(mappedBy = "treeHouse")
     private List<Invitation> invitationList;
+
+    public void addMember(Member member) {
+        memberList.add(member);
+    }
 }


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
Mapper 클래스의 파라미터를 수정하고 NotificationType enum을 5개로 늘립니다

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- MemberMapper.toMember 파라미터 변경
- MemberMapper.toRegister 파라미터 변경
- 트리하우스 가입 완료 시, 감정표현 저장 완료 시, 연관관계 편의 메서드 호출
- NotificationType enum 추가 - INVITATION(초대), COMMENT(댓글), REPLY(답글), POST_REACTION(게시글 반응), COMMENT_REACTION(댓글 반응)

## ⏳ 작업 내용
- [x] MemberMapper.toMember 
- [x] MemberMapper.toRegsiter
- [x] MemberService - register 메서드 
- [x] PostService - reactToPost 메서드
- [x] CommentService - reactToComment 메서드
- [ ] NotificationType enum 추가

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

