### PR TITLE
Feat/71 대댓글 관련 로직 및 조회, 작성 API 구현

### DIFF
--- a/src/main/java/treehouse/server/api/comment/business/CommentMapper.java
+++ b/src/main/java/treehouse/server/api/comment/business/CommentMapper.java
@@ -4,6 +4,7 @@ import treehouse.server.api.comment.presentation.dto.CommentResponseDTO;
 import treehouse.server.api.member.business.MemberMapper;
 import treehouse.server.api.reaction.presentation.dto.ReactionResponseDTO;
 import treehouse.server.global.entity.comment.Comment;
+import treehouse.server.global.entity.comment.CommentType;
 import treehouse.server.global.entity.member.Member;
 import treehouse.server.global.entity.post.Post;
 
@@ -42,11 +43,13 @@ public class CommentMapper {
                 .build();
     }
 
-    public static Comment toComment(Member writer, Post post, String content) {
+    public static Comment toComment(Member writer, Post post, String content, CommentType type, Long parentId) {
         return Comment.builder()
                 .writer(writer)
                 .post(post)
                 .content(content)
+                .type(type)
+                .parentId(parentId)
                 .build();
     }
 

--- a/src/main/java/treehouse/server/api/comment/business/CommentMapper.java
+++ b/src/main/java/treehouse/server/api/comment/business/CommentMapper.java
@@ -12,8 +12,21 @@ import java.util.List;
 public class CommentMapper {
 
 
-    public static CommentResponseDTO.CommentInfoDto toCommentInfoDto(Comment comment, ReactionResponseDTO.getReactionList reactionList) {
+    public static CommentResponseDTO.CommentInfoDto toCommentInfoDto(Comment comment, ReactionResponseDTO.getReactionList reactionList,
+                                                                     List<CommentResponseDTO.ReplyInfoDto> replyInfoDtoList) {
         return CommentResponseDTO.CommentInfoDto.builder()
+                .commentedAt(comment.getCreatedAt().toString())
+                .commentId(comment.getId())
+                .context(comment.getContent())
+                .reactionList(reactionList)
+                .replyList(replyInfoDtoList)
+                .memberProfile(MemberMapper.toGetWriterProfile(comment.getWriter()))
+                .build();
+
+    }
+
+    public static CommentResponseDTO.ReplyInfoDto toReplyInfoDto(Comment comment, ReactionResponseDTO.getReactionList reactionList) {
+        return CommentResponseDTO.ReplyInfoDto.builder()
                 .commentedAt(comment.getCreatedAt().toString())
                 .commentId(comment.getId())
                 .context(comment.getContent())

--- a/src/main/java/treehouse/server/api/comment/business/CommentService.java
+++ b/src/main/java/treehouse/server/api/comment/business/CommentService.java
@@ -24,6 +24,7 @@ import treehouse.server.api.treehouse.implementation.TreehouseQueryAdapter;
 import treehouse.server.api.user.implement.UserQueryAdapter;
 import treehouse.server.global.entity.User.User;
 import treehouse.server.global.entity.comment.Comment;
+import treehouse.server.global.entity.comment.CommentType;
 import treehouse.server.global.entity.member.Member;
 import treehouse.server.global.entity.post.Post;
 import treehouse.server.global.entity.reaction.Reaction;
@@ -161,9 +162,20 @@ public class CommentService {
         Post post = postQueryAdapter.findById(postId);
         Member writer = memberQueryAdapter.findByUserAndTreehouse(user, treehouse);
 
-        Comment comment = CommentMapper.toComment(writer, post, request.getContext());
+        Comment comment = CommentMapper.toComment(writer, post, request.getContext(), CommentType.PARENT, -1L);
         Long commentId = commentCommandAdapter.createComment(comment).getId();
         return CommentMapper.toIdResponseDto(commentId);
+    }
+
+    public CommentResponseDTO.CommentIdResponseDto createReply(User user, Long treehouseId, Long postId, Long parentId, CommentRequestDTO.createComment request){
+
+        TreeHouse treehouse = treehouseQueryAdapter.getTreehouseById(treehouseId);
+        Post post = postQueryAdapter.findById(postId);
+        Member writer = memberQueryAdapter.findByUserAndTreehouse(user, treehouse);
+
+        Comment comment = CommentMapper.toComment(writer, post, request.getContext(), CommentType.CHILD, parentId);
+        Long replyId = commentCommandAdapter.createComment(comment).getId();
+        return CommentMapper.toIdResponseDto(replyId);
     }
 
     public void deleteComment(User user, Long treehouseId, Long postId, Long commentId) {

--- a/src/main/java/treehouse/server/api/comment/business/CommentService.java
+++ b/src/main/java/treehouse/server/api/comment/business/CommentService.java
@@ -87,12 +87,16 @@ public class CommentService {
         Member member = memberQueryAdapter.findByUserAndTreehouse(user, treehouse);
 
         Pageable pageable = PageRequest.of(page, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
-        List<Comment> commentListByPostId = commentQueryAdapter.getCommentListByPostId(postId, pageable);
+//        List<Comment> commentListByPostId = commentQueryAdapter.getCommentListByPostId(postId, pageable);
+        List<Comment> commentListByPostId = commentQueryAdapter.getParentCommentListByPostId(postId, pageable);
 
+        log.error("PO size : {}", commentListByPostId.size());
         // 신고된 댓글을 필터링
         List<Comment> filteredComments = commentListByPostId.stream()
                 .filter(comment -> !reportQueryAdapter.isReportedComment(comment))
                 .collect(Collectors.toList());
+
+        log.error("size : {}", filteredComments.size());
 
         // 각 댓글마다 reactionList를 생성
         List<CommentResponseDTO.CommentInfoDto> commentInfoDtoList = filteredComments.stream()
@@ -111,9 +115,41 @@ public class CommentService {
                             ));
                     ReactionResponseDTO.getReactionList reactionDtoList = ReactionMapper.toGetReactionList(reactionMap);
 
-                    return CommentMapper.toCommentInfoDto(comment, reactionDtoList);
+                    // 여기서 comment 에 대한 reply 목록을 조회해서 List<ReplyInfoDto> 를 만든 다음, mapper에 매개변수로 넣고, mapper 코드 업데이트 하자.
+
+                    // 1. queryAdapter 에 parentId 가지고 childList 조회하는 메서드 만들기
+                    List<Comment> childCommentList = commentQueryAdapter.getChildCommentListByPostIdAndParentId(postId, comment.getId(), pageable);
+
+                    // 2. mapper 에 childList를 각각 comment 에서 ReplyInfoDto 로 바꾸는 메서드 만들기
+                    // 각 답글마다 reactionList를 생성
+                    List<CommentResponseDTO.ReplyInfoDto> replyInfoDtoList = childCommentList.stream()
+                            .map(reply -> {
+                                List<Reaction> replyReactions = reactionQueryAdapter.findAllByComment(reply);
+                                Map<String, ReactionResponseDTO.getReaction> replyReactionMap = replyReactions.stream()
+                                        .collect(Collectors.toMap(
+                                                Reaction::getReactionName,
+                                                reaction -> {
+                                                    String reactionName = reaction.getReactionName();
+                                                    Integer reactionCount = reactionQueryAdapter.countReactionsByReactionNameAndCommentId(reactionName, reply.getId());
+                                                    Boolean isPushed = reactionQueryAdapter.existByMemberAndCommentAndReactionName(member, reply, reactionName);
+                                                    return ReactionMapper.toGetReaction(reaction, reactionCount, isPushed);
+                                                },
+                                                (existing, replacement) -> existing // 중복되는 경우 기존 값을 사용
+                                        ));
+                                ReactionResponseDTO.getReactionList replyReactionDtoList = ReactionMapper.toGetReactionList(replyReactionMap);
+
+                                return CommentMapper.toReplyInfoDto(reply, replyReactionDtoList);
+                            })
+                            .collect(Collectors.toList());
+
+
+                    // 3. mapper 에 이렇게 만든 childList 를 포함해서 최종 응답 형태인 CommentList 로 바꾸는 메서드 만들고 호출하기
+
+                    return CommentMapper.toCommentInfoDto(comment, reactionDtoList,replyInfoDtoList);
                 })
                 .collect(Collectors.toList());
+
+        log.error("commentListDto size : {}", commentListByPostId.size());
 
         CommentResponseDTO.CommentListDto commentListDto = CommentMapper.toCommentListDto(commentInfoDtoList);
         return commentListDto;

--- a/src/main/java/treehouse/server/api/comment/implementation/CommentQueryAdapter.java
+++ b/src/main/java/treehouse/server/api/comment/implementation/CommentQueryAdapter.java
@@ -2,9 +2,15 @@ package treehouse.server.api.comment.implementation;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import treehouse.server.api.comment.business.CommentMapper;
 import treehouse.server.api.comment.persistence.CommentRepository;
+import treehouse.server.api.comment.presentation.dto.CommentResponseDTO;
+import treehouse.server.api.reaction.business.ReactionMapper;
+import treehouse.server.api.reaction.presentation.dto.ReactionResponseDTO;
 import treehouse.server.global.annotations.Adapter;
 import treehouse.server.global.entity.comment.Comment;
+import treehouse.server.global.entity.comment.CommentType;
+import treehouse.server.global.entity.reaction.Reaction;
 import treehouse.server.global.exception.GlobalErrorCode;
 import treehouse.server.global.exception.ThrowClass.CommentException;
 
@@ -12,6 +18,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Adapter
 @RequiredArgsConstructor
@@ -27,4 +35,15 @@ public class CommentQueryAdapter {
     public List<Comment> getCommentListByPostId(Long postId, Pageable pageable) {
         return commentRepository.findAllByPostId(postId, pageable);
     }
+
+    public List<Comment> getParentCommentListByPostId(Long postId, Pageable pageable) {
+        log.error("post id : {}",postId);
+        return commentRepository.findAllByPostIdAndType(postId, CommentType.PARENT, pageable);
+    }
+
+    public List<Comment> getChildCommentListByPostIdAndParentId(Long postId, Long parentId, Pageable pageable) {
+        return commentRepository.findAllByPostIdAndTypeAndParentId(postId, CommentType.CHILD, parentId, pageable);
+    }
+
 }
+

--- a/src/main/java/treehouse/server/api/comment/persistence/CommentRepository.java
+++ b/src/main/java/treehouse/server/api/comment/persistence/CommentRepository.java
@@ -3,11 +3,16 @@ package treehouse.server.api.comment.persistence;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import treehouse.server.global.entity.comment.Comment;
+import treehouse.server.global.entity.comment.CommentType;
 
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     List<Comment> findAllByPostId(Long postId, Pageable pageable);
+
+    List<Comment> findAllByPostIdAndType(Long postId, CommentType type, Pageable pageable);
+
+    List<Comment> findAllByPostIdAndTypeAndParentId(Long postId, CommentType type, Long parentId, Pageable pageable);
 
 }

--- a/src/main/java/treehouse/server/api/comment/presentation/CommentApi.java
+++ b/src/main/java/treehouse/server/api/comment/presentation/CommentApi.java
@@ -61,6 +61,19 @@ public class CommentApi {
         return CommonResponse.onSuccess(commentService.createComment(user, treehouseId, postId, request));
     }
 
+    @PostMapping("/{commentId}")
+    @Operation(summary = "대댓글 작성 API 🔑", description = "특정 Comment에 대해서 대댓글을 작성하는 API 입니다.")
+    public CommonResponse<CommentResponseDTO.CommentIdResponseDto> createReply(
+            @PathVariable(name = "treehouseId")Long treehouseId,
+            @PathVariable(name = "postId")Long postId,
+            @PathVariable(name = "commentId")Long commentId,
+            @AuthMember @Parameter(hidden = true) User user,
+            @RequestBody CommentRequestDTO.createComment request
+    )
+    {
+        return CommonResponse.onSuccess(commentService.createReply(user, treehouseId, postId, commentId, request));
+    }
+
     @DeleteMapping("/{commentId}")
     @Operation(summary = "댓글 삭제 API 🔑", description = "댓글을 삭제하는 API 입니다.")
     public CommonResponse deleteComment(

--- a/src/main/java/treehouse/server/api/comment/presentation/dto/CommentResponseDTO.java
+++ b/src/main/java/treehouse/server/api/comment/presentation/dto/CommentResponseDTO.java
@@ -22,8 +22,22 @@ public class CommentResponseDTO {
         ReactionResponseDTO.getReactionList reactionList;
         Long commentId;
         String context;
+        List<ReplyInfoDto> replyList;
         String commentedAt;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReplyInfoDto{
+        MemberResponseDTO.getWriterProfile memberProfile;
+        ReactionResponseDTO.getReactionList reactionList;
+        Long commentId;
+        String context;
+        String commentedAt;
+    }
+
 
     @Builder
     @Getter

--- a/src/main/java/treehouse/server/global/entity/comment/Comment.java
+++ b/src/main/java/treehouse/server/global/entity/comment/Comment.java
@@ -25,4 +25,11 @@ public class  Comment extends BaseDateTimeEntity {
     @JoinColumn(name = "postId")
     @ManyToOne(fetch = FetchType.LAZY)
     private Post post;
+
+    @JoinColumn(name = "parentId")
+    private Long parentId;
+
+    @JoinColumn(name = "type")
+    @Enumerated(EnumType.STRING)
+    private CommentType type;
 }

--- a/src/main/java/treehouse/server/global/entity/comment/CommentType.java
+++ b/src/main/java/treehouse/server/global/entity/comment/CommentType.java
@@ -1,0 +1,6 @@
+package treehouse.server.global.entity.comment;
+
+public enum CommentType {
+
+    PARENT, CHILD;
+}


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 대댓글 위한 엔티티 필드 및 Enum 추가
- 댓글 조회 api - 대댓글 함께 조회되도록 수정
- 대댓글 작성 API 구현

## ⏳ 작업 내용
- [x] 대댓글 위한 엔티티 필드 및 Enum 추가
- [x] 댓글 조회 api - 대댓글 함께 조회되도록 수정
- [x] 대댓글 작성 API 구현

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

