### PR TITLE
Feature/75 - 트리하우스 정보 조회 API 및 하드코딩으로 채워뒀던 코드들 수정

### DIFF
--- a/src/main/java/treehouse/server/api/comment/business/CommentMapper.java
+++ b/src/main/java/treehouse/server/api/comment/business/CommentMapper.java
@@ -4,6 +4,7 @@ import treehouse.server.api.comment.presentation.dto.CommentResponseDTO;
 import treehouse.server.api.member.business.MemberMapper;
 import treehouse.server.api.reaction.presentation.dto.ReactionResponseDTO;
 import treehouse.server.global.common.util.TimeFormatter;
+import treehouse.server.global.entity.branch.Branch;
 import treehouse.server.global.entity.comment.Comment;
 import treehouse.server.global.entity.comment.CommentType;
 import treehouse.server.global.entity.member.Member;
@@ -14,7 +15,7 @@ import java.util.List;
 public class CommentMapper {
 
 
-    public static CommentResponseDTO.CommentInfoDto toCommentInfoDto(Comment comment, ReactionResponseDTO.getReactionList reactionList,
+    public static CommentResponseDTO.CommentInfoDto toCommentInfoDto(Member member, List<Branch> branches, Comment comment, ReactionResponseDTO.getReactionList reactionList,
                                                                      List<CommentResponseDTO.ReplyInfoDto> replyInfoDtoList) {
         return CommentResponseDTO.CommentInfoDto.builder()
                 .commentedAt(TimeFormatter.format(comment.getCreatedAt()))
@@ -22,18 +23,18 @@ public class CommentMapper {
                 .context(comment.getContent())
                 .reactionList(reactionList)
                 .replyList(replyInfoDtoList)
-                .memberProfile(MemberMapper.toGetWriterProfile(comment.getWriter()))
+                .memberProfile(MemberMapper.toGetWriterProfile(member, comment.getWriter(), branches))
                 .build();
 
     }
 
-    public static CommentResponseDTO.ReplyInfoDto toReplyInfoDto(Comment comment, ReactionResponseDTO.getReactionList reactionList) {
+    public static CommentResponseDTO.ReplyInfoDto toReplyInfoDto(Member member, List<Branch> branches, Comment comment, ReactionResponseDTO.getReactionList reactionList) {
         return CommentResponseDTO.ReplyInfoDto.builder()
                 .commentedAt(TimeFormatter.format(comment.getCreatedAt()))
                 .commentId(comment.getId())
                 .context(comment.getContent())
                 .reactionList(reactionList)
-                .memberProfile(MemberMapper.toGetWriterProfile(comment.getWriter()))
+                .memberProfile(MemberMapper.toGetWriterProfile(member, comment.getWriter(), branches))
                 .build();
 
     }

--- a/src/main/java/treehouse/server/api/comment/business/CommentService.java
+++ b/src/main/java/treehouse/server/api/comment/business/CommentService.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import treehouse.server.api.branch.implementation.BranchQueryAdapter;
 import treehouse.server.api.comment.implementation.CommentCommandAdapter;
 import treehouse.server.api.comment.implementation.CommentQueryAdapter;
 import treehouse.server.api.comment.presentation.dto.CommentRequestDTO;
@@ -23,6 +24,7 @@ import treehouse.server.api.report.implementation.ReportQueryAdapter;
 import treehouse.server.api.treehouse.implementation.TreehouseQueryAdapter;
 import treehouse.server.api.user.implement.UserQueryAdapter;
 import treehouse.server.global.entity.User.User;
+import treehouse.server.global.entity.branch.Branch;
 import treehouse.server.global.entity.comment.Comment;
 import treehouse.server.global.entity.comment.CommentType;
 import treehouse.server.global.entity.member.Member;
@@ -59,6 +61,8 @@ public class CommentService {
     private final ReactionCommandAdapter reactionCommandAdapter;
     private final ReactionQueryAdapter reactionQueryAdapter;
 
+    private final BranchQueryAdapter branchQueryAdapter;
+
 
     public void reportComment(User user, CommentRequestDTO.reportComment request, Long treehouseId, Long postId, Long commentId){
 
@@ -86,6 +90,7 @@ public class CommentService {
 
         TreeHouse treehouse = treehouseQueryAdapter.getTreehouseById(treehouseId);
         Member member = memberQueryAdapter.findByUserAndTreehouse(user, treehouse);
+        List<Branch> branches = branchQueryAdapter.findAllByTreeHouse(treehouse);
 
         Pageable pageable = PageRequest.of(page, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
 //        List<Comment> commentListByPostId = commentQueryAdapter.getCommentListByPostId(postId, pageable);
@@ -134,11 +139,11 @@ public class CommentService {
                                         ));
                                 ReactionResponseDTO.getReactionList replyReactionDtoList = ReactionMapper.toGetReactionList(replyReactionMap);
 
-                                return CommentMapper.toReplyInfoDto(reply, replyReactionDtoList);
+                                return CommentMapper.toReplyInfoDto(member, branches, reply, replyReactionDtoList);
                             })
                             .collect(Collectors.toList());
 
-                    return CommentMapper.toCommentInfoDto(comment, reactionDtoList,replyInfoDtoList);
+                    return CommentMapper.toCommentInfoDto(member, branches, comment, reactionDtoList,replyInfoDtoList);
                 })
                 .collect(Collectors.toList());
 

--- a/src/main/java/treehouse/server/api/invitation/business/InvitationMapper.java
+++ b/src/main/java/treehouse/server/api/invitation/business/InvitationMapper.java
@@ -23,6 +23,7 @@ public class InvitationMapper {
     public static InvitationResponseDTO.getInvitation toGetInvitation (Invitation invitation, List<String> treeMemberProfileImages) {
         return InvitationResponseDTO.getInvitation.builder()
                 .invitationId(invitation.getId())
+                .treehouseId(invitation.getTreeHouse().getId())
                 .treehouseName(invitation.getTreeHouse().getName())
                 .senderName(invitation.getSender().getName())
                 .senderProfileImageUrl(invitation.getSender().getProfileImageUrl())
@@ -63,6 +64,7 @@ public class InvitationMapper {
                 .phone(phoneNumber)
                 .expiredAt(sevenDaysLater)
                 .status(InvitationStatus.PENDING)
+                .treeHouse(treeHouse)
                 .build();
     }
 

--- a/src/main/java/treehouse/server/api/invitation/business/InvitationService.java
+++ b/src/main/java/treehouse/server/api/invitation/business/InvitationService.java
@@ -15,6 +15,8 @@ import treehouse.server.global.entity.Invitation.Invitation;
 import treehouse.server.global.entity.User.User;
 import treehouse.server.global.entity.member.Member;
 import treehouse.server.global.entity.treeHouse.TreeHouse;
+import treehouse.server.global.exception.GlobalErrorCode;
+import treehouse.server.global.exception.ThrowClass.InvitationException;
 import treehouse.server.global.exception.ThrowClass.UserException;
 
 import java.util.List;
@@ -64,7 +66,6 @@ public class InvitationService {
 
     @Transactional
     public InvitationResponseDTO.createInvitation createInvitation(User user, InvitationRequestDTO.createInvitation request){
-
         // 트리 찾기
         TreeHouse treehouse = treehouseQueryAdapter.getTreehouseById(request.getTreehouseId());
         // 초대 멤버 찾기
@@ -92,8 +93,10 @@ public class InvitationService {
     public InvitationResponseDTO.invitationAccept decisionInvitation(User user, InvitationRequestDTO.invitationAcceptDecision request){
         // 해당 User 에게 온 초대장인지 검증하는 로직 추가
         Long treehouseId = 0L;
+        Invitation invitation = invitationQueryAdapter.findById(request.getInvitationId());
+
         if (request.isAcceptDecision()==true) {
-            treehouseId = 1L; // treehouse 관련 로직 개발 후, invitation.getTreeHouse.getId() 등으로 바꾸기
+            treehouseId = invitation.getTreeHouse().getId(); // treehouse 관련 로직 개발 후, invitation.getTreeHouse.getId() 등으로 바꾸기
         }
         return InvitationMapper.toInvitationResult(treehouseId);
     }

--- a/src/main/java/treehouse/server/api/invitation/implement/InvitationQueryAdapter.java
+++ b/src/main/java/treehouse/server/api/invitation/implement/InvitationQueryAdapter.java
@@ -8,6 +8,7 @@ import treehouse.server.global.annotations.Adapter;
 import treehouse.server.global.entity.Invitation.Invitation;
 import treehouse.server.global.entity.User.User;
 import treehouse.server.global.exception.GlobalErrorCode;
+import treehouse.server.global.exception.ThrowClass.InvitationException;
 import treehouse.server.global.exception.ThrowClass.UserException;
 
 import java.util.List;
@@ -25,5 +26,10 @@ public class InvitationQueryAdapter {
 
     public Boolean existByPhoneNumber(String phoneNumber) {
         return invitationRepository.existsByPhone(phoneNumber);
+    }
+
+    public Invitation findById(Long invitationId) {
+        return invitationRepository.findById(invitationId)
+                .orElseThrow(() -> new InvitationException(GlobalErrorCode.INVITATION_NOT_FOUND));
     }
 }

--- a/src/main/java/treehouse/server/api/invitation/presentation/dto/InvitationResponseDTO.java
+++ b/src/main/java/treehouse/server/api/invitation/presentation/dto/InvitationResponseDTO.java
@@ -13,6 +13,7 @@ public class InvitationResponseDTO {
     @AllArgsConstructor
     public static class getInvitation {
         private Long invitationId;
+        private Long treehouseId;
         private String treehouseName;
         private String senderName;
         private String senderProfileImageUrl;

--- a/src/main/java/treehouse/server/api/member/business/MemberMapper.java
+++ b/src/main/java/treehouse/server/api/member/business/MemberMapper.java
@@ -38,12 +38,12 @@ public class MemberMapper {
                 .build();
     }
 
-    public static MemberResponseDTO.getWriterProfile toGetWriterProfile(Member member) {
+    public static MemberResponseDTO.getWriterProfile toGetWriterProfile(Member member, Member writer, List<Branch> branches) {
         return MemberResponseDTO.getWriterProfile.builder()
-                .memberId(member.getId())
-                .memberName(member.getName())
-                .memberProfileImageUrl(member.getProfileImageUrl())
-                .memberBranch(3) // Branch 기능 개발 이후 변경 예정
+                .memberId(writer.getId())
+                .memberName(writer.getName())
+                .memberProfileImageUrl(writer.getProfileImageUrl())
+                .memberBranch(BranchUtil.calculateBranchDegree(branches, member.getId(), writer.getId()))
                 .build();
     }
 

--- a/src/main/java/treehouse/server/api/post/business/PostMapper.java
+++ b/src/main/java/treehouse/server/api/post/business/PostMapper.java
@@ -7,6 +7,7 @@ import treehouse.server.api.post.presentation.dto.PostResponseDTO;
 import treehouse.server.api.member.business.MemberMapper;
 import treehouse.server.api.reaction.presentation.dto.ReactionResponseDTO;
 import treehouse.server.global.common.util.TimeFormatter;
+import treehouse.server.global.entity.branch.Branch;
 import treehouse.server.global.entity.member.Member;
 import treehouse.server.global.entity.post.Post;
 import treehouse.server.global.entity.post.PostImage;
@@ -19,9 +20,9 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class PostMapper {
 
-    public static PostResponseDTO.getPostDetails toGetPostDetails(Post post, List<String> postImageUrlList, ReactionResponseDTO.getReactionList reactionList) {
+    public static PostResponseDTO.getPostDetails toGetPostDetails(Member member, List<Branch> branches, Post post, List<String> postImageUrlList, ReactionResponseDTO.getReactionList reactionList) {
         return PostResponseDTO.getPostDetails.builder()
-                .memberProfile(MemberMapper.toGetWriterProfile(post.getWriter()))
+                .memberProfile(MemberMapper.toGetWriterProfile(member, post.getWriter(), branches))
                 .postId(post.getId())
                 .context(post.getContent())
                 .pictureUrlList(postImageUrlList)
@@ -42,9 +43,9 @@ public class PostMapper {
                 .build();
     }
 
-    public static PostResponseDTO.getMemberPostList toGetMemberPostList(Member targetMember, List<PostResponseDTO.getOnlyPostDetail> onlyPostDetailList) {
+    public static PostResponseDTO.getMemberPostList toGetMemberPostList(Member member, Member targetMember, List<PostResponseDTO.getOnlyPostDetail> onlyPostDetailList, List<Branch> branches) {
         return PostResponseDTO.getMemberPostList.builder()
-                .memberProfile(MemberMapper.toGetWriterProfile(targetMember))
+                .memberProfile(MemberMapper.toGetWriterProfile(member, targetMember, branches))
                 .postList(onlyPostDetailList)
                 .build();
     }

--- a/src/main/java/treehouse/server/api/treehouse/business/TreehouseMapper.java
+++ b/src/main/java/treehouse/server/api/treehouse/business/TreehouseMapper.java
@@ -20,4 +20,13 @@ public class TreehouseMapper {
                 .treehouseId(treehouse.getId())
                 .build();
     }
+
+    public static TreehouseResponseDTO.getTreehouseDetails toGetTreehouseDetails(TreeHouse treehouse) {
+        return TreehouseResponseDTO.getTreehouseDetails.builder()
+                .treehouseId(treehouse.getId())
+                .treehouseName(treehouse.getName())
+                .treehouseSize(treehouse.getMemberList().size())
+                .treehouseImageUrl(null) //TODO: 이미지 URL 설정
+                .build();
+    }
 }

--- a/src/main/java/treehouse/server/api/treehouse/business/TreehouseService.java
+++ b/src/main/java/treehouse/server/api/treehouse/business/TreehouseService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import treehouse.server.api.member.implementation.MemberQueryAdapter;
 import treehouse.server.api.treehouse.implementation.TreehouseCommandAdapter;
+import treehouse.server.api.treehouse.implementation.TreehouseQueryAdapter;
 import treehouse.server.api.treehouse.presentation.dto.TreehouseRequestDTO;
 import treehouse.server.api.treehouse.presentation.dto.TreehouseResponseDTO;
 import treehouse.server.global.entity.treeHouse.TreeHouse;
@@ -17,6 +18,7 @@ import treehouse.server.global.entity.treeHouse.TreeHouse;
 public class TreehouseService {
 
     private final TreehouseCommandAdapter treehouseCommandAdapter;
+    private final TreehouseQueryAdapter treehouseQueryAdapter;
 
     private final MemberQueryAdapter memberQueryAdapter;
 
@@ -26,6 +28,11 @@ public class TreehouseService {
         TreeHouse savedTreehouse = treehouseCommandAdapter.saveTreehouse(treehouse);
 
         return TreehouseMapper.toCreateTreehouse(savedTreehouse);
+    }
+
+    public TreehouseResponseDTO.getTreehouseDetails getTreehouseDetails(Long treehouseId) {
+        TreeHouse treehouse = treehouseQueryAdapter.getTreehouseById(treehouseId);
+        return TreehouseMapper.toGetTreehouseDetails(treehouse);
     }
 
 

--- a/src/main/java/treehouse/server/api/treehouse/presentation/TreehouseApi.java
+++ b/src/main/java/treehouse/server/api/treehouse/presentation/TreehouseApi.java
@@ -5,10 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import treehouse.server.api.treehouse.business.TreehouseService;
 import treehouse.server.api.treehouse.presentation.dto.TreehouseRequestDTO;
 import treehouse.server.api.treehouse.presentation.dto.TreehouseResponseDTO;
@@ -30,5 +27,13 @@ public class TreehouseApi {
             @RequestBody TreehouseRequestDTO.createTreehouse request
     ) {
         return CommonResponse.onSuccess(treehouseService.createTreehouse(request));
+    }
+
+    @GetMapping("/{treehouseId}")
+    @Operation(summary = "트리하우스 조회 🔑", description = "트리하우스 정보를 조회합니다.")
+    public CommonResponse<TreehouseResponseDTO.getTreehouseDetails> getTreehouseDetails(
+            @PathVariable Long treehouseId
+    ) {
+        return CommonResponse.onSuccess(treehouseService.getTreehouseDetails(treehouseId));
     }
 }

--- a/src/main/java/treehouse/server/api/treehouse/presentation/dto/TreehouseResponseDTO.java
+++ b/src/main/java/treehouse/server/api/treehouse/presentation/dto/TreehouseResponseDTO.java
@@ -13,4 +13,16 @@ public class TreehouseResponseDTO {
 
         private Long treehouseId;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class getTreehouseDetails {
+
+        private Long treehouseId;
+        private String treehouseName;
+        private Integer treehouseSize;
+        private String treehouseImageUrl;
+    }
 }

--- a/src/main/java/treehouse/server/global/entity/Invitation/Invitation.java
+++ b/src/main/java/treehouse/server/global/entity/Invitation/Invitation.java
@@ -23,6 +23,7 @@ public class Invitation extends BaseDateTimeEntity {
     private String phone;
 
     @Setter
+    @Enumerated(EnumType.STRING)
     private InvitationStatus status;
 
     private LocalDateTime expiredAt; //초대장 만료일자

--- a/src/main/java/treehouse/server/global/exception/ThrowClass/InvitationException.java
+++ b/src/main/java/treehouse/server/global/exception/ThrowClass/InvitationException.java
@@ -1,0 +1,10 @@
+package treehouse.server.global.exception.ThrowClass;
+
+import treehouse.server.global.exception.BaseErrorCode;
+
+public class InvitationException extends GeneralException{
+
+    public InvitationException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
트리하우스 정보 조회 API 및 하드코딩으로 채워뒀던 코드들 수정

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- Invitation 수락 관련 로직에서 treehouseId관련 누락된 부분 수정
- 게시글/댓글 작성자와 현재 로그인한 사용자 사이의 Branch 지수를 표현하는 로직 추가

## ⏳ 작업 내용
- [x] **POST** /users/invitations/accept
- [x] **GET** /treehouses/{treehouseId}
- [x] 게시글 단일 조회
- [x] 게시글 목록 조회
- [x] 특정 멤버가 작성한 게시글 목록 조회
- [x] 댓글&답글 목록 조회

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

