### PR TITLE
✨ Feat: 알림 조회 문구의 구체화 및 읽음 처리 기능

### DIFF
--- a/src/main/java/treehouse/server/api/invitation/business/InvitationService.java
+++ b/src/main/java/treehouse/server/api/invitation/business/InvitationService.java
@@ -9,11 +9,14 @@ import treehouse.server.api.invitation.implement.InvitationQueryAdapter;
 import treehouse.server.api.invitation.presentation.dto.InvitationRequestDTO;
 import treehouse.server.api.invitation.presentation.dto.InvitationResponseDTO;
 import treehouse.server.api.member.implementation.MemberQueryAdapter;
+import treehouse.server.api.notification.business.NotificationService;
+import treehouse.server.api.notification.presentation.dto.NotificationRequestDTO;
 import treehouse.server.api.treehouse.implementation.TreehouseQueryAdapter;
 import treehouse.server.api.user.implement.UserQueryAdapter;
 import treehouse.server.global.entity.Invitation.Invitation;
 import treehouse.server.global.entity.User.User;
 import treehouse.server.global.entity.member.Member;
+import treehouse.server.global.entity.notification.NotificationType;
 import treehouse.server.global.entity.treeHouse.TreeHouse;
 import treehouse.server.global.exception.GlobalErrorCode;
 import treehouse.server.global.exception.ThrowClass.InvitationException;
@@ -37,6 +40,8 @@ public class InvitationService {
     private final MemberQueryAdapter memberQueryAdapter;
 
     private final UserQueryAdapter userQueryAdapter;
+
+    private final NotificationService notificationService;
 
     private static final Integer treeMemberRandomProfileSize = 3;
 
@@ -83,6 +88,13 @@ public class InvitationService {
         // 초대장 만들어서 저장하기
 
         Invitation invitation = invitationCommandAdapter.saveInvitation(InvitationMapper.toInvitation(request.getPhoneNumber(), sender, receiverUser, treehouse));
+
+        //알림 생성
+        NotificationRequestDTO.createNotification notificationRequest = new NotificationRequestDTO.createNotification();
+        notificationRequest.setReceiverId(receiverUser.getId()); // 여기서 receiver 설정 (예시)
+        notificationRequest.setTargetId(invitation.getId());
+        notificationRequest.setType(NotificationType.INVITATION); // 알림 타입 설정 (예시)
+        notificationService.createNotification(user, invitation.getTreeHouse().getId(), notificationRequest, null);
 
         // 리턴하기
 

--- a/src/main/java/treehouse/server/api/notification/business/NotificationMapper.java
+++ b/src/main/java/treehouse/server/api/notification/business/NotificationMapper.java
@@ -2,21 +2,41 @@ package treehouse.server.api.notification.business;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import treehouse.server.api.notification.presentation.dto.NotificationRequestDTO;
 import treehouse.server.api.notification.presentation.dto.NotificationResponseDTO;
+import treehouse.server.global.common.util.TimeFormatter;
 import treehouse.server.global.entity.User.User;
+import treehouse.server.global.entity.member.Member;
 import treehouse.server.global.entity.notification.Notification;
+import treehouse.server.global.entity.notification.NotificationType;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class NotificationMapper {
+
+    public static Notification toNotification(Member sender, Member receiver, NotificationRequestDTO.createNotification request, String reactionName) {
+
+        return Notification.builder()
+                .sender(sender)
+                .receiver(receiver)
+                .type(request.getType())
+                .targetId(request.getTargetId())
+                .title(NotificationUtil.getTitle(request.getType()))
+                .body(NotificationUtil.getBody(request.getType(), sender, request.getTargetId(), reactionName))
+                .receivedTime(LocalDateTime.now())
+                .build();
+    }
 
     public static NotificationResponseDTO.getNotification toGetNotification(Notification notification, User user) {
         return NotificationResponseDTO.getNotification.builder()
                 .type(notification.getType())
                 .profileImageUrl(notification.getSender().getProfileImageUrl())
                 .userName(notification.getSender().getName())
-                .receivedTime(String.valueOf(notification.getReceivedTime()))
+                .title(notification.getTitle())
+                .body(notification.getBody())
+                .receivedTime(TimeFormatter.format(notification.getReceivedTime()))
                 .treehouseId(notification.getSender().getTreeHouse().getId())
                 .treehouseName(notification.getSender().getTreeHouse().getName())
                 .isChecked(notification.isChecked())
@@ -27,6 +47,12 @@ public class NotificationMapper {
     public static NotificationResponseDTO.getNotifications toGetNotifications(List<NotificationResponseDTO.getNotification> notificationDtos) {
         return NotificationResponseDTO.getNotifications.builder()
                 .notifications(notificationDtos)
+                .build();
+    }
+
+    public static NotificationResponseDTO.readNotification toReadNotification(Notification notification) {
+        return NotificationResponseDTO.readNotification.builder()
+                .notificationId(notification.getId())
                 .build();
     }
 }

--- a/src/main/java/treehouse/server/api/notification/business/NotificationUtil.java
+++ b/src/main/java/treehouse/server/api/notification/business/NotificationUtil.java
@@ -1,0 +1,36 @@
+package treehouse.server.api.notification.business;
+
+import org.apache.commons.lang3.function.TriFunction;
+import treehouse.server.global.entity.member.Member;
+import treehouse.server.global.entity.notification.NotificationType;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+public class NotificationUtil {
+
+    private static final Map<NotificationType, String> titleMap = new EnumMap<>(NotificationType.class);
+    private static final Map<NotificationType, TriFunction<Member, Long, String, String>> bodyMap = new EnumMap<>(NotificationType.class);
+
+    static {
+        titleMap.put(NotificationType.COMMENT, "댓글 알림");
+        titleMap.put(NotificationType.REPLY, "대댓글 알림");
+        titleMap.put(NotificationType.INVITATION, "초대 알림");
+        titleMap.put(NotificationType.POST_REACTION, "게시글 반응 알림");
+        titleMap.put(NotificationType.COMMENT_REACTION, "댓글 반응 알림");
+
+        bodyMap.put(NotificationType.COMMENT, (sender, targetId, reactionName) -> sender.getName() + " 님이 댓글을 남겼습니다.");
+        bodyMap.put(NotificationType.REPLY, (sender, targetId, reactionName) -> sender.getName() + " 님이 답글을 남겼습니다.");
+        bodyMap.put(NotificationType.INVITATION, (sender, targetId, reactionName) -> sender.getName() + " 님이 트리하우스에 초대했습니다.");
+        bodyMap.put(NotificationType.POST_REACTION, (sender, targetId, reactionName) -> sender.getName() + " 님이 게시글에 " + reactionName + "을(를) 눌렀습니다.");
+        bodyMap.put(NotificationType.COMMENT_REACTION, (sender, targetId, reactionName) -> sender.getName() + " 님이 댓글에 " + reactionName + "을(를) 눌렀습니다.");
+    }
+
+    public static String getTitle(NotificationType type) {
+        return titleMap.getOrDefault(type, "Notification");
+    }
+
+    public static String getBody(NotificationType type, Member sender, Long targetId, String reactionName) {
+        return bodyMap.getOrDefault(type, (s, t, r) -> "알림이 있습니다.").apply(sender, targetId, reactionName);
+    }
+}

--- a/src/main/java/treehouse/server/api/notification/implement/NotificationCommandAdapter.java
+++ b/src/main/java/treehouse/server/api/notification/implement/NotificationCommandAdapter.java
@@ -2,10 +2,23 @@ package treehouse.server.api.notification.implement;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import treehouse.server.api.notification.persistence.NotificationRepository;
 import treehouse.server.global.annotations.Adapter;
+import treehouse.server.global.entity.notification.Notification;
 
 @Adapter
 @RequiredArgsConstructor
 @Slf4j
 public class NotificationCommandAdapter {
+
+    private final NotificationRepository notificationRepository;
+
+    public void createNotification(Notification notification){
+        notificationRepository.save(notification);
+    }
+
+    public void readNotification(Notification notification) {
+        notification.setChecked(true);
+        notificationRepository.save(notification);
+    }
 }

--- a/src/main/java/treehouse/server/api/notification/implement/NotificationQueryAdapter.java
+++ b/src/main/java/treehouse/server/api/notification/implement/NotificationQueryAdapter.java
@@ -1,9 +1,19 @@
 package treehouse.server.api.notification.implement;
 
 import lombok.RequiredArgsConstructor;
+import treehouse.server.api.notification.persistence.NotificationRepository;
 import treehouse.server.global.annotations.Adapter;
+import treehouse.server.global.entity.notification.Notification;
+import treehouse.server.global.exception.GlobalErrorCode;
+import treehouse.server.global.exception.ThrowClass.NotificationException;
 
 @Adapter
 @RequiredArgsConstructor
 public class NotificationQueryAdapter {
+
+    private final NotificationRepository notificationRepository;
+    public Notification findById(Long notificationId) {
+        return notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new NotificationException(GlobalErrorCode.NOTIFICATION_NOT_FOUND));
+    }
 }

--- a/src/main/java/treehouse/server/api/notification/presentation/NotificationApi.java
+++ b/src/main/java/treehouse/server/api/notification/presentation/NotificationApi.java
@@ -7,6 +7,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 import treehouse.server.api.notification.business.NotificationService;
 import treehouse.server.api.notification.presentation.dto.NotificationResponseDTO;
@@ -29,5 +31,14 @@ public class NotificationApi {
             @AuthMember @Parameter(hidden = true) User user
     ){
         return CommonResponse.onSuccess(notificationService.getNotifications(user));
+    }
+
+    @PostMapping("/users/notifications/{notificationId}")
+    @Operation(summary = "알림 확인 🔑 ✅", description = "사용자의 알림을 확인하여 '읽음' 상태로 변경합니다.")
+    public CommonResponse<NotificationResponseDTO.readNotification> readNotification(
+            @AuthMember @Parameter(hidden = true) User user,
+            @PathVariable Long notificationId
+    ){
+        return CommonResponse.onSuccess(notificationService.readNotification(user, notificationId));
     }
 }

--- a/src/main/java/treehouse/server/api/notification/presentation/dto/NotificationRequestDTO.java
+++ b/src/main/java/treehouse/server/api/notification/presentation/dto/NotificationRequestDTO.java
@@ -1,0 +1,23 @@
+package treehouse.server.api.notification.presentation.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import treehouse.server.api.notification.business.NotificationService;
+import treehouse.server.global.entity.notification.NotificationType;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class NotificationRequestDTO {
+
+    @Getter
+    @Setter
+    public static class createNotification {
+
+        private String title;
+        private String body;
+        private NotificationType type;
+        private Long targetId;
+        private Long receiverId;
+    }
+}

--- a/src/main/java/treehouse/server/api/notification/presentation/dto/NotificationResponseDTO.java
+++ b/src/main/java/treehouse/server/api/notification/presentation/dto/NotificationResponseDTO.java
@@ -14,6 +14,8 @@ public class NotificationResponseDTO {
     @AllArgsConstructor
     public static class getNotification {
         private NotificationType type;
+        private String title;
+        private String body;
         private String profileImageUrl;
         private String userName;
         private String receivedTime;
@@ -29,5 +31,13 @@ public class NotificationResponseDTO {
     @AllArgsConstructor
     public static class getNotifications {
         List<NotificationResponseDTO.getNotification> notifications;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class readNotification {
+        private Long notificationId;
     }
 }

--- a/src/main/java/treehouse/server/api/post/business/PostService.java
+++ b/src/main/java/treehouse/server/api/post/business/PostService.java
@@ -11,6 +11,8 @@ import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 import treehouse.server.api.branch.implementation.BranchQueryAdapter;
 import treehouse.server.api.member.implementation.MemberQueryAdapter;
+import treehouse.server.api.notification.business.NotificationService;
+import treehouse.server.api.notification.presentation.dto.NotificationRequestDTO;
 import treehouse.server.api.post.implement.PostCommandAdapter;
 import treehouse.server.api.post.implement.PostImageCommandAdapter;
 import treehouse.server.api.post.implement.PostQueryAdapter;
@@ -28,6 +30,7 @@ import treehouse.server.global.constants.Consts;
 import treehouse.server.global.entity.User.User;
 import treehouse.server.global.entity.branch.Branch;
 import treehouse.server.global.entity.member.Member;
+import treehouse.server.global.entity.notification.NotificationType;
 import treehouse.server.global.entity.post.Post;
 import treehouse.server.global.entity.post.PostImage;
 import treehouse.server.global.entity.reaction.Reaction;
@@ -69,6 +72,8 @@ public class PostService {
     private final ReportQueryAdapter reportQueryAdapter;
 
     private final BranchQueryAdapter branchQueryAdapter;
+
+    private final NotificationService notificationService;
 
     /**
      * 게시글 상세조회
@@ -299,6 +304,13 @@ public class PostService {
         Reaction savedReaction = reactionCommandAdapter.saveReaction(reaction);
 
         member.addReaction(savedReaction);
+
+        //알림 생성
+        NotificationRequestDTO.createNotification notificationRequest = new NotificationRequestDTO.createNotification();
+        notificationRequest.setReceiverId(post.getWriter().getId()); // 여기서 receiver 설정 (예시)
+        notificationRequest.setTargetId(post.getId());
+        notificationRequest.setType(NotificationType.POST_REACTION); // 알림 타입 설정 (예시)
+        notificationService.createNotification(user, treehouseId, notificationRequest, savedReaction.getReactionName());
 
         return request.getReactionName() + " is saved";
     }

--- a/src/main/java/treehouse/server/global/entity/notification/Notification.java
+++ b/src/main/java/treehouse/server/global/entity/notification/Notification.java
@@ -1,10 +1,7 @@
 package treehouse.server.global.entity.notification;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import treehouse.server.global.entity.common.BaseDateTimeEntity;
 import treehouse.server.global.entity.member.Member;
 
@@ -23,6 +20,8 @@ public class Notification extends BaseDateTimeEntity {
     private String title;
 
     private String body;
+
+    @Setter
     private boolean isChecked;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/treehouse/server/global/exception/ThrowClass/NotificationException.java
+++ b/src/main/java/treehouse/server/global/exception/ThrowClass/NotificationException.java
@@ -1,0 +1,9 @@
+package treehouse.server.global.exception.ThrowClass;
+
+import treehouse.server.global.exception.BaseErrorCode;
+
+public class NotificationException extends GeneralException{
+    public NotificationException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
알림 조회 문구의 구체화 및 읽음 처리 기능

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 감정표현 알림 조회 시 이모지도 출력

## ⏳ 작업 내용
- [x] NotificationType(댓글,답글, 감정표현, 초대)에 해당하는 로직 실행 시, 알림 객체도 생성하도록 수정
- [x] 알림 종류에 따른 title, body 매핑 및 감정표현 관련 알림 조회 시, 어떤 이모지를 남겼는지도 출력
- [x] 특정 알림을 눌러 직접 확인한 경우, isChecked를 true로 변경하는 api 구현

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

