### PR TITLE
Feat/104 FCM 푸시 알림 관련 로직 추가, API 추가

### DIFF
--- a/src/main/java/treehouse/server/api/notification/business/NotificationService.java
+++ b/src/main/java/treehouse/server/api/notification/business/NotificationService.java
@@ -10,10 +10,12 @@ import treehouse.server.api.notification.implement.NotificationQueryAdapter;
 import treehouse.server.api.notification.presentation.dto.NotificationRequestDTO;
 import treehouse.server.api.notification.presentation.dto.NotificationResponseDTO;
 import treehouse.server.api.treehouse.implementation.TreehouseQueryAdapter;
+import treehouse.server.api.user.implement.UserQueryAdapter;
 import treehouse.server.global.entity.User.User;
 import treehouse.server.global.entity.member.Member;
 import treehouse.server.global.entity.notification.Notification;
 import treehouse.server.global.entity.treeHouse.TreeHouse;
+import treehouse.server.global.fcm.service.FcmService;
 
 import java.util.Comparator;
 import java.util.List;
@@ -31,6 +33,8 @@ public class NotificationService {
 
     private final TreehouseQueryAdapter treehouseQueryAdapter;
 
+    private final FcmService fcmService;
+
     /**
      * 알림 생성하는 로직
      * @param user
@@ -42,8 +46,9 @@ public class NotificationService {
         TreeHouse treeHouse = treehouseQueryAdapter.getTreehouseById(treehouseId);
         Member sender = memberQueryAdapter.findByUserAndTreehouse(user, treeHouse);
         Member receiver = memberQueryAdapter.findById(request.getReceiverId());
-
         Notification notification = NotificationMapper.toNotification(sender, receiver, request, reactionName);
+
+        fcmService.sendFcmMessage(receiver.getUser(), notification.getTitle(), notification.getBody());
         notificationCommandAdapter.createNotification(notification);
     }
 

--- a/src/main/java/treehouse/server/api/user/business/UserMapper.java
+++ b/src/main/java/treehouse/server/api/user/business/UserMapper.java
@@ -3,6 +3,7 @@ package treehouse.server.api.user.business;
 import jakarta.annotation.PostConstruct;
 import lombok.*;
 import org.springframework.stereotype.Component;
+import treehouse.server.api.user.presentation.dto.UserRequestDTO;
 import treehouse.server.api.user.presentation.dto.UserResponseDTO;
 import treehouse.server.global.entity.User.User;
 import treehouse.server.global.entity.User.UserRole;
@@ -78,6 +79,13 @@ public class UserMapper {
     public static UserResponseDTO.withdraw toWithdraw(User user) {
         return UserResponseDTO.withdraw.builder()
                 .userId(user.getId())
+                .build();
+    }
+
+    public static UserResponseDTO.pushAgree toPushAgree(User user, UserRequestDTO.pushAgreeDto request) {
+        return UserResponseDTO.pushAgree.builder()
+                .userId(user.getId())
+                .isPushAgree(request.isPushAgree())
                 .build();
     }
 }

--- a/src/main/java/treehouse/server/api/user/business/UserMapper.java
+++ b/src/main/java/treehouse/server/api/user/business/UserMapper.java
@@ -88,4 +88,11 @@ public class UserMapper {
                 .isPushAgree(request.isPushAgree())
                 .build();
     }
+
+    public static UserResponseDTO.saveFcmToken toSaveFcmToken(User user, boolean isSuccess) {
+        return UserResponseDTO.saveFcmToken.builder()
+                .userId(user.getId())
+                .isSaveFcmToken(isSuccess)
+                .build();
+    }
 }

--- a/src/main/java/treehouse/server/api/user/business/UserService.java
+++ b/src/main/java/treehouse/server/api/user/business/UserService.java
@@ -16,6 +16,7 @@ import treehouse.server.global.entity.redis.RefreshToken;
 import treehouse.server.global.exception.GlobalErrorCode;
 import treehouse.server.global.exception.ThrowClass.AuthException;
 import treehouse.server.global.exception.ThrowClass.GeneralException;
+import treehouse.server.global.fcm.service.FcmService;
 import treehouse.server.global.redis.service.RedisService;
 import treehouse.server.global.security.jwt.dto.TokenDTO;
 import treehouse.server.global.security.provider.TokenProvider;
@@ -38,6 +39,8 @@ public class UserService {
 
     private final InvitationQueryAdapter invitationQueryAdapter;
     private final UserRepository userRepository;
+
+    private final FcmService fcmService;
 
     @Transactional(readOnly = true)
     public UserResponseDTO.checkName checkName(UserRequestDTO.checkName request){

--- a/src/main/java/treehouse/server/api/user/business/UserService.java
+++ b/src/main/java/treehouse/server/api/user/business/UserService.java
@@ -97,4 +97,10 @@ public class UserService {
 
         return UserMapper.toWithdraw(user);
     }
+
+    @Transactional
+    public UserResponseDTO.pushAgree updatePushAgree(User user, UserRequestDTO.pushAgreeDto request){
+        boolean pushAgree = user.updatePushAgree(request.isPushAgree());
+        return UserMapper.toPushAgree(user, request);
+    }
 }

--- a/src/main/java/treehouse/server/api/user/persistence/FcmTokenRepository.java
+++ b/src/main/java/treehouse/server/api/user/persistence/FcmTokenRepository.java
@@ -16,5 +16,5 @@ public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
 
     boolean existsByUserAndToken(User user, String token);
 
-    List<FcmToken> findAllByUser(User user);
+    List<FcmToken> findAllByUserAndPushAllowed(User user, boolean pushAllowed);
 }

--- a/src/main/java/treehouse/server/api/user/persistence/FcmTokenRepository.java
+++ b/src/main/java/treehouse/server/api/user/persistence/FcmTokenRepository.java
@@ -16,5 +16,5 @@ public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
 
     boolean existsByUserAndToken(User user, String token);
 
-    List<FcmToken> findAllByUserAndPushAllowed(User user, boolean pushAllowed);
+    List<FcmToken> findAllByUser(User user);
 }

--- a/src/main/java/treehouse/server/api/user/presentation/UserApi.java
+++ b/src/main/java/treehouse/server/api/user/presentation/UserApi.java
@@ -12,6 +12,8 @@ import treehouse.server.api.user.presentation.dto.UserRequestDTO;
 import treehouse.server.api.user.presentation.dto.UserResponseDTO;
 import treehouse.server.global.common.CommonResponse;
 import treehouse.server.global.entity.User.User;
+import treehouse.server.global.fcm.dto.FCMDto;
+import treehouse.server.global.fcm.service.FcmService;
 import treehouse.server.global.security.handler.annotation.AuthMember;
 
 @RestController
@@ -23,6 +25,7 @@ import treehouse.server.global.security.handler.annotation.AuthMember;
 public class UserApi {
 
     private final UserService userService;
+    private final FcmService fcmService;
 
     @PostMapping("/checkName")
     @Operation(summary = "아이디 중복 체크 ✅", description = "서비스에서 사용할 유저이름을 중복 체크합니다.")
@@ -76,11 +79,18 @@ public class UserApi {
     @Operation(summary = "푸시 알림 동의 API 🔑✅️", description = "푸시 알림 동의 API입니다.")
     public CommonResponse<UserResponseDTO.pushAgree> pushAgree(
             @AuthMember @Parameter(hidden = true) User user,
-            UserRequestDTO.pushAgreeDto request
+            @RequestBody UserRequestDTO.pushAgreeDto request
     ){
         return CommonResponse.onSuccess(userService.updatePushAgree(user,request));
     }
 
 
-
+    @PostMapping("/fcm-token")
+    @Operation(summary = "FCM 토큰 저장 API 🔑✅️", description = "FCM 토큰 저장 API입니다.")
+    public CommonResponse<UserResponseDTO.saveFcmToken> saveFcmToken(
+            @AuthMember @Parameter(hidden = true) User user,
+            @RequestBody FCMDto.saveFcmTokenDto request
+            ){
+        return CommonResponse.onSuccess(fcmService.saveFcmToken(user,request));
+    }
 }

--- a/src/main/java/treehouse/server/api/user/presentation/UserApi.java
+++ b/src/main/java/treehouse/server/api/user/presentation/UserApi.java
@@ -71,4 +71,16 @@ public class UserApi {
     ){
         return CommonResponse.onSuccess(userService.withdraw(user));
     }
+
+    @PostMapping("/push-agree")
+    @Operation(summary = "푸시 알림 동의 API 🔑✅️", description = "푸시 알림 동의 API입니다.")
+    public CommonResponse<UserResponseDTO.pushAgree> pushAgree(
+            @AuthMember @Parameter(hidden = true) User user,
+            UserRequestDTO.pushAgreeDto request
+    ){
+        return CommonResponse.onSuccess(userService.updatePushAgree(user,request));
+    }
+
+
+
 }

--- a/src/main/java/treehouse/server/api/user/presentation/UserApi.java
+++ b/src/main/java/treehouse/server/api/user/presentation/UserApi.java
@@ -72,6 +72,7 @@ public class UserApi {
     public CommonResponse<UserResponseDTO.withdraw> withdraw(
             @AuthMember @Parameter(hidden = true) User user
     ){
+        fcmService.deleteAllFcmToken(user);
         return CommonResponse.onSuccess(userService.withdraw(user));
     }
 

--- a/src/main/java/treehouse/server/api/user/presentation/dto/UserRequestDTO.java
+++ b/src/main/java/treehouse/server/api/user/presentation/dto/UserRequestDTO.java
@@ -2,10 +2,7 @@ package treehouse.server.api.user.presentation.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 
 public class UserRequestDTO {
@@ -63,5 +60,10 @@ public class UserRequestDTO {
     @Getter
     public static class checkUserStatus {
         private String phoneNumber;
+    }
+
+    @Getter
+    public static class pushAgreeDto{
+        boolean pushAgree;
     }
 }

--- a/src/main/java/treehouse/server/api/user/presentation/dto/UserResponseDTO.java
+++ b/src/main/java/treehouse/server/api/user/presentation/dto/UserResponseDTO.java
@@ -81,4 +81,13 @@ public class UserResponseDTO {
     public static class withdraw {
         private Long userId;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class pushAgree {
+        private Long userId;
+        private boolean isPushAgree;
+    }
 }

--- a/src/main/java/treehouse/server/api/user/presentation/dto/UserResponseDTO.java
+++ b/src/main/java/treehouse/server/api/user/presentation/dto/UserResponseDTO.java
@@ -90,4 +90,13 @@ public class UserResponseDTO {
         private Long userId;
         private boolean isPushAgree;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class saveFcmToken {
+        private Long userId;
+        private boolean isSaveFcmToken;
+    }
 }

--- a/src/main/java/treehouse/server/global/entity/User/FcmToken.java
+++ b/src/main/java/treehouse/server/global/entity/User/FcmToken.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
+import treehouse.server.global.entity.common.BaseDateTimeEntity;
 
 @Getter
 @Builder
@@ -12,7 +13,7 @@ import org.hibernate.annotations.DynamicUpdate;
 @DynamicUpdate
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class FcmToken {
+public class FcmToken extends BaseDateTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/treehouse/server/global/exception/GlobalErrorCode.java
+++ b/src/main/java/treehouse/server/global/exception/GlobalErrorCode.java
@@ -99,8 +99,9 @@ public enum GlobalErrorCode implements BaseErrorCode{
     PHONE_AUTH_WRONG(BAD_REQUEST, "NCP400_2", "잘못된 인증 번호 입니다."),
     PHONE_AUTH_TIMEOUT(BAD_REQUEST, "NCP400_3", "인증 시간이 초과되었습니다."),
 
+    FCM_ALREADY_EXISTS_TOKEN(BAD_REQUEST, "FCM400_1", "이미 저장되어 있는 FCM 토큰입니다."),
     FCM_ACCESS_TOKEN_REQUEST_ERROR(INTERNAL_SERVER_ERROR, "FCM500_2", "서버 에러, FCM 서버에 AccessToken 요청할 때 에러 발생."),
-    FCM_SEND_MESSAGE_ERROR(INTERNAL_SERVER_ERROR, "FCM500_3", "서버 에러, FCM 서버에 메시지를 전송할 때 에러 발생. FcmToken이 유효한지 확인해주세요.");
+    FCM_SEND_MESSAGE_ERROR(INTERNAL_SERVER_ERROR    , "FCM500_3", "서버 에러, FCM 서버에 메시지를 전송할 때 에러 발생. FcmToken이 유효한지 확인해주세요.");
 
     ;
 

--- a/src/main/java/treehouse/server/global/fcm/service/FcmService.java
+++ b/src/main/java/treehouse/server/global/fcm/service/FcmService.java
@@ -96,4 +96,9 @@ public class FcmService {
 
 
     }
+
+    @Transactional
+    public void deleteAllFcmToken(User user) {
+        fcmTokenRepository.deleteAllByUser(user);
+    }
 }

--- a/src/main/java/treehouse/server/global/fcm/service/FcmService.java
+++ b/src/main/java/treehouse/server/global/fcm/service/FcmService.java
@@ -14,6 +14,7 @@ import treehouse.server.global.entity.User.FcmToken;
 import treehouse.server.global.entity.User.User;
 import treehouse.server.global.exception.GlobalErrorCode;
 import treehouse.server.global.exception.ThrowClass.FcmException;
+import treehouse.server.global.fcm.dto.FCMDto;
 
 import java.util.List;
 
@@ -50,7 +51,7 @@ public class FcmService {
             return;
         }
 
-        List<FcmToken> fcmTokenList = fcmTokenRepository.findAllByUser(receiver);
+        List<FcmToken> fcmTokenList = fcmTokenRepository.findAllByUserAndPushAllowed(receiver, true);
         if (fcmTokenList.isEmpty()) {
             return;
         }


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
FCM 푸시 알림 관련 로직 추가, API 추가
## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 기존 알림에 FCM 푸시 알림 전송 로직 추가
- 푸시 알림 동의/거부 API 구현
- FCM 토큰 값 저장 API 구현
- 회원 탈퇴 시, 해당 유저의 fcm 토큰 모두 지우도록 기능 추가

## ⏳ 작업 내용
- [x] 기존 알림에 FCM 푸시 알림 전송 로직 추가
- [x] API 구현
- [x] 회원 탈퇴 관련 로직 추가

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

