### PR TITLE
🐛 Fix: 아직 회원가입 하지 않은 사람에게 초대장을 보낸 경우, 알림 데이터 생성하지 않도록 수정

### DIFF
--- a/src/main/java/treehouse/server/api/invitation/business/InvitationService.java
+++ b/src/main/java/treehouse/server/api/invitation/business/InvitationService.java
@@ -77,25 +77,20 @@ public class InvitationService {
         Member sender = memberQueryAdapter.findByUserAndTreehouse(user, treehouse);
         // 초대 대상이 가입된 사람인지 찾기
 
-        User receiverUser = null;
+        User receiverUser = userQueryAdapter.findByPhoneNumberOptional(request.getPhoneNumber()).orElse(null);
 
-        try {
-            receiverUser = userQueryAdapter.findByPhoneNumber(request.getPhoneNumber());
-        }
-        catch (UserException e){
-            // 뭐 안함
-        }
         // 초대장 만들어서 저장하기
 
         Invitation invitation = invitationCommandAdapter.saveInvitation(InvitationMapper.toInvitation(request.getPhoneNumber(), sender, receiverUser, treehouse));
 
         //알림 생성
-        NotificationRequestDTO.createNotification notificationRequest = new NotificationRequestDTO.createNotification();
-        notificationRequest.setReceiverId(receiverUser.getId()); // 여기서 receiver 설정 (예시)
-        notificationRequest.setTargetId(invitation.getId());
-        notificationRequest.setType(NotificationType.INVITATION); // 알림 타입 설정 (예시)
-        notificationService.createNotification(user, invitation.getTreeHouse().getId(), notificationRequest, null);
-
+        if (receiverUser != null) {
+            NotificationRequestDTO.createNotification notificationRequest = new NotificationRequestDTO.createNotification();
+            notificationRequest.setReceiverId(receiverUser.getId()); // 여기서 receiver 설정 (예시)
+            notificationRequest.setTargetId(invitation.getId());
+            notificationRequest.setType(NotificationType.INVITATION); // 알림 타입 설정 (예시)
+            notificationService.createNotification(user, invitation.getTreeHouse().getId(), notificationRequest, null);
+        }
         // 리턴하기
 
         return InvitationMapper.toCreateInvitationDTO(invitation);

--- a/src/main/java/treehouse/server/api/notification/business/NotificationService.java
+++ b/src/main/java/treehouse/server/api/notification/business/NotificationService.java
@@ -46,9 +46,9 @@ public class NotificationService {
     public void createNotification(User user, Long treehouseId, NotificationRequestDTO.createNotification request, String reactionName) {
         TreeHouse treeHouse = treehouseQueryAdapter.getTreehouseById(treehouseId);
         Member sender = memberQueryAdapter.findByUserAndTreehouse(user, treeHouse);
-        User receiver = userQueryAdapter.findById(request.getReceiverId());
+        User receiver = userQueryAdapter.findByIdOptional(request.getReceiverId()).orElse(null);
         Notification notification = NotificationMapper.toNotification(sender, receiver, request, reactionName);
-        if(user.isPushAgree()) {
+        if(user.isPushAgree() && receiver != null) {
             fcmService.sendFcmMessage(receiver, notification.getTitle(), notification.getBody());
         }
         notificationCommandAdapter.createNotification(notification);

--- a/src/main/java/treehouse/server/api/user/implement/UserQueryAdapter.java
+++ b/src/main/java/treehouse/server/api/user/implement/UserQueryAdapter.java
@@ -30,8 +30,16 @@ public class UserQueryAdapter {
         return userRepository.findByPhone(phone).orElseThrow(()->new UserException(GlobalErrorCode.USER_NOT_FOUND));
     }
 
+    public Optional<User> findByPhoneNumberOptional(String phone){
+        return userRepository.findByPhone(phone);
+    }
+
     public User findById(Long id){
         return userRepository.findById(id).orElseThrow(()->new UserException(GlobalErrorCode.USER_NOT_FOUND));
+    }
+
+    public Optional<User> findByIdOptional(Long id){
+        return userRepository.findById(id);
     }
 
     public Optional<User> optionalUserFindById(Long id){


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
아직 회원가입 하지 않은 사람에게 초대장을 보낸 경우, 알림 데이터 생성하지 않도록 수정

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- UserQueryAdapter에 Optional값으로 반환하는 메서드 2개 생성(findByIdOptional, findByPhoneOptional)

## ⏳ 작업 내용
- [x] #111 

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

